### PR TITLE
Fill in VersioningService and usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ Currently implemented Services
   - [x] query
   - [x] getContentChanges
 - VersioningService
-  - [ ] checkOut
-  - [ ] cancelCheckOut
-  - [ ] checkIn
-  - [ ] getObjectOfLatestVersion
-  - [ ] getPropertiesOfLatestVersion
-  - [ ] getAllVersions
+  - [x] checkOut
+  - [x] cancelCheckOut
+  - [x] checkIn
+  - [x] getObjectOfLatestVersion
+  - [x] getPropertiesOfLatestVersion
+  - [x] getAllVersions
 - RelationshipService
   - [x] getObjectRelationships
 - PolicyService

--- a/examples/Versioning.php
+++ b/examples/Versioning.php
@@ -1,0 +1,121 @@
+<?php
+require_once(__DIR__ . '/../vendor/autoload.php');
+if (!is_file(__DIR__ . '/conf/Configuration.php')) {
+	die("Please add your connection credentials to the file \"" . __DIR__ . "/conf/Configuration.php\".\n");
+} else {
+	require_once(__DIR__ . '/conf/Configuration.php');
+}
+
+// Extracting arguments for example script
+$major = (boolean) isset($argv[1]) ? $argv[1] : false;
+
+$httpInvoker = new \GuzzleHttp\Client(
+	array(
+		'defaults' => array(
+			'auth' => array(
+				CMIS_BROWSER_USER,
+				CMIS_BROWSER_PASSWORD
+			)
+		)
+	)
+);
+
+$parameters = array(
+	\Dkd\PhpCmis\SessionParameter::BINDING_TYPE => \Dkd\PhpCmis\Enum\BindingType::BROWSER,
+	\Dkd\PhpCmis\SessionParameter::BROWSER_URL => CMIS_BROWSER_URL,
+	\Dkd\PhpCmis\SessionParameter::BROWSER_SUCCINCT => false,
+	\Dkd\PhpCmis\SessionParameter::HTTP_INVOKER_OBJECT => $httpInvoker,
+);
+
+$sessionFactory = new \Dkd\PhpCmis\SessionFactory();
+
+// If no repository id is defined use the first repository
+if (CMIS_REPOSITORY_ID === null) {
+	$repositories = $sessionFactory->getRepositories($parameters);
+	$repositoryId = $repositories[0]->getId();
+} else {
+	$repositoryId = CMIS_REPOSITORY_ID;
+}
+
+$parameters[\Dkd\PhpCmis\SessionParameter::REPOSITORY_ID] = $repositoryId;
+
+$session = $sessionFactory->createSession($parameters);
+$rootFolder = $session->getObject($session->createObjectId($session->getRootFolder()->getId()));
+
+try {
+
+	$document = null;
+	$stream = \GuzzleHttp\Stream\Stream::factory(fopen(__DIR__ . '/../README.md', 'r'));
+	foreach ($rootFolder->getChildren() as $child) {
+		if ($child->getName() === 'Demo Object') {
+			echo "[*] Using existing README.md document in repository root folder.\n";
+			$document = $child;
+			break;
+		}
+	}
+
+	if (!$document) {
+		echo "[*] Create CMIS Document with file README.md\n";
+
+		$properties = array(
+			\Dkd\PhpCmis\PropertyIds::OBJECT_TYPE_ID => 'cmis:document',
+			\Dkd\PhpCmis\PropertyIds::NAME => 'Demo Object'
+		);
+
+		$document = $session->createDocument($properties, $rootFolder, $stream);
+		$document = $session->getObject($document);
+
+		echo "[*] Document has been created. Document Id: " . $document->getId() . "\n";
+	}
+
+	$checkedOutDocumentId = $document->getVersionSeriesCheckedOutId();
+	if ($checkedOutDocumentId) {
+		echo "[*] Document is already checked out - resuming working copy\n";
+		$checkedOutDocumentId = $session->createObjectId($checkedOutDocumentId);
+	} else {
+		echo "[*] Checking out document to private working copy (PWC)... ";
+		$checkedOutDocumentId = $document->checkOut();
+		echo "done!\n";
+
+	}
+
+	echo "[*] Versioned ID before: " . $document->getId() . "\n";
+	echo "[*] Versioned ID during checkout: ". $checkedOutDocumentId . "\n";
+
+	echo "[*] Checking in with updated properties (";
+	if ($major) {
+		echo 'major';
+	} else {
+		echo 'minor - to make a major revision pass a "1" - one - as argument to the example script';
+	}
+	echo ")\n";
+
+	$checkedInDocumentId = $session->getObject($checkedOutDocumentId)->checkIn(
+		$major,
+		array(
+			\Dkd\PhpCmis\PropertyIds::DESCRIPTION => 'New description'
+		),
+		$stream,
+		'Checked out/in by system'
+	);
+
+
+	echo "[*] Versioned ID after: " . $checkedInDocumentId->getId() . "\n\n";
+
+	echo "The following versions of README.md are now stored in the repository:\n";
+	foreach ($document->getAllVersions() as $version) {
+		echo "  * " . $version->getVersionLabel() . ' ';
+		echo $version->isLatestVersion() ? 'LATEST' : '';
+		echo $version->isLatestMajorVersion() ? 'LATEST MAJOR' : '';
+		echo "\n";
+	}
+	echo "\n";
+
+	echo "Please delete README.md from repository now by hand if you so wish!\n";
+	echo "You can run this script again if you don't - it will use the same file/document.\n";
+} catch (\Dkd\PhpCmis\Exception\CmisVersioningException $e) {
+	echo "********* ERROR **********\n";
+	echo $e->getMessage() . "\n";
+	echo "**************************\n";
+	exit();
+}

--- a/src/Bindings/Browser/VersioningService.php
+++ b/src/Bindings/Browser/VersioningService.php
@@ -12,6 +12,7 @@ namespace Dkd\PhpCmis\Bindings\Browser;
 
 use Dkd\PhpCmis\Constants;
 use Dkd\PhpCmis\Data\AclInterface;
+use Dkd\PhpCmis\PropertyIds;
 use GuzzleHttp\Stream\StreamInterface;
 use Dkd\PhpCmis\Data\ExtensionDataInterface;
 use Dkd\PhpCmis\Data\ObjectDataInterface;
@@ -31,9 +32,18 @@ class VersioningService extends AbstractBrowserBindingService implements Version
      * @param string $objectId the identifier for the PWC
      * @param ExtensionDataInterface|null $extension
      */
-    public function cancelCheckOut($repositoryId, $objectId, ExtensionDataInterface $extension = null)
+    public function cancelCheckOut($repositoryId, & $objectId, ExtensionDataInterface $extension = null)
     {
-        // TODO: Implement cancelCheckOut() method.
+		$objectId = $this->getJsonConverter()->convertObject(
+			$this->post(
+				$this->getObjectUrl($repositoryId, $objectId),
+				$this->createQueryArray(
+					Constants::CMISACTION_CANCEL_CHECK_OUT,
+					array(),
+					$extension
+				)
+			)->json()
+		);
     }
 
     /**
@@ -56,7 +66,7 @@ class VersioningService extends AbstractBrowserBindingService implements Version
      */
     public function checkIn(
         $repositoryId,
-        $objectId,
+        & $objectId,
         $major = true,
         PropertiesInterface $properties = null,
         StreamInterface $contentStream = null,
@@ -66,7 +76,51 @@ class VersioningService extends AbstractBrowserBindingService implements Version
         AclInterface $removeAces = null,
         ExtensionDataInterface $extension = null
     ) {
-        // TODO: Implement checkIn() method.
+		$queryArray = $this->createQueryArray(
+			Constants::CMISACTION_CHECK_IN,
+			array(
+				Constants::PARAM_MAJOR => $major ? 'true' : 'false',
+			),
+			$extension
+		);
+		if ($properties) {
+			$queryArray = array_replace(
+				$queryArray,
+				$this->convertPropertiesToQueryArray($properties)
+			);
+		}
+		if ($checkinComment) {
+			$queryArray[Constants::PARAM_CHECKIN_COMMENT] = $checkinComment;
+		}
+		if (!empty($policies)) {
+			$queryArray = array_replace(
+				$queryArray,
+				$this->convertPolicyIdArrayToQueryArray($policies)
+			);
+		}
+		if (!empty($removeAces)) {
+			$queryArray = array_replace($queryArray, $this->convertAclToQueryArray(
+				$removeAces,
+				Constants::CONTROL_REMOVE_ACE_PRINCIPAL,
+				Constants::CONTROL_REMOVE_ACE_PERMISSION
+			));
+		}
+		if (!empty($addAces)) {
+			$queryArray = array_replace($queryArray, $this->convertAclToQueryArray(
+				$addAces,
+				Constants::CONTROL_ADD_ACE_PRINCIPAL,
+				Constants::CONTROL_ADD_ACE_PERMISSION
+			));
+		}
+		if ($contentStream) {
+			$queryArray['content'] = $contentStream;
+		}
+		$objectId = $this->getJsonConverter()->convertObject(
+			$this->post(
+				$this->getObjectUrl($repositoryId, $objectId),
+				$queryArray
+			)->json()
+		);
     }
 
     /**
@@ -85,7 +139,17 @@ class VersioningService extends AbstractBrowserBindingService implements Version
         ExtensionDataInterface $extension = null,
         $contentCopied = null
     ) {
-        // TODO: Implement checkOut() method.
+		$objectData = $this->getJsonConverter()->convertObject(
+			$this->post(
+				$this->getObjectUrl($repositoryId, $objectId),
+				$this->createQueryArray(
+					Constants::CMISACTION_CHECK_OUT,
+					array(),
+					$extension
+				)
+			)->json()
+		);
+		$objectId = $objectData->getId();
     }
 
     /**
@@ -110,7 +174,13 @@ class VersioningService extends AbstractBrowserBindingService implements Version
         $includeAllowableActions = false,
         ExtensionDataInterface $extension = null
     ) {
-        // TODO: Implement getAllVersions() method.
+        return $this->getJsonConverter()->convertObjectList(
+			array(
+				'objects' => $this->read(
+					$this->getObjectUrl($repositoryId, $objectId, Constants::SELECTOR_VERSIONS)
+				)->json()
+			)
+		)->getObjects();
     }
 
     /**
@@ -147,7 +217,13 @@ class VersioningService extends AbstractBrowserBindingService implements Version
         $includeAcl = false,
         ExtensionDataInterface $extension = null
     ) {
-        // TODO: Implement getObjectOfLatestVersion() method.
+		return $this->getJsonConverter()->convertObject(
+			reset(
+				$this->read(
+					$this->getObjectUrl($repositoryId, $objectId, Constants::SELECTOR_VERSIONS)
+				)->json()
+			)
+		);
     }
 
     /**
@@ -173,6 +249,35 @@ class VersioningService extends AbstractBrowserBindingService implements Version
         $filter = null,
         ExtensionDataInterface $extension = null
     ) {
-        // TODO: Implement getPropertiesOfLatestVersion() method.
+        return $this->getObjectOfLatestVersion(
+			$repositoryId,
+			$objectId,
+			$versionSeriesId,
+			$major,
+			$filter,
+			$extension
+		)->getProperties();
     }
+
+	/**
+	 * @param string $action
+	 * @param array $parameters
+	 * @param ExtensionDataInterface $extension
+	 * @return array
+	 */
+	protected function createQueryArray(
+		$action,
+		array $parameters = array(),
+		ExtensionDataInterface $extension = null
+	) {
+		$queryArray = array_replace(
+			$parameters,
+			array(
+				Constants::CONTROL_CMISACTION => $action,
+				Constants::PARAM_SUCCINCT => $this->getSuccinct() ? 'true' : 'false',
+			)
+		);
+		return $queryArray;
+	}
+
 }

--- a/src/DataObjects/Document.php
+++ b/src/DataObjects/Document.php
@@ -22,6 +22,7 @@ use Dkd\PhpCmis\Enum\Updatability;
 use Dkd\PhpCmis\Enum\VersioningState;
 use Dkd\PhpCmis\Exception\CmisNotSupportedException;
 use Dkd\PhpCmis\Exception\CmisRuntimeException;
+use Dkd\PhpCmis\Exception\CmisVersioningException;
 use Dkd\PhpCmis\OperationContextInterface;
 use Dkd\PhpCmis\Data\PolicyInterface;
 use Dkd\PhpCmis\PropertyIds;
@@ -135,7 +136,7 @@ class Document extends AbstractFileableCmisObject implements DocumentInterface
             $objectFactory->convertPolicies($policies),
             $objectFactory->convertAces($addAces),
             $objectFactory->convertAces($removeAces)
-        );
+        )->getId();
 
         // remove PWC from cache, it doesn't exist anymore
         $this->getSession()->removeObjectFromCache($this);
@@ -144,7 +145,7 @@ class Document extends AbstractFileableCmisObject implements DocumentInterface
             return null;
         }
 
-        $this->getSession()->createObjectId($newObjectId);
+        return $this->getSession()->createObjectId($newObjectId);
     }
 
     /**
@@ -375,12 +376,17 @@ class Document extends AbstractFileableCmisObject implements DocumentInterface
 
         $objectFactory = $this->getSession()->getObjectFactory();
         $result = array();
-        if (count($versions) !== null) {
+        if (count($versions)) {
             foreach ($versions as $objectData) {
                 $document = $objectFactory->convertObject($objectData, $context);
-                if (!(!$document instanceof DocumentInterface)) {
-                    // this should never happen
-                    continue;
+                if (!($document instanceof DocumentInterface)) {
+                    throw new CmisVersioningException(
+						sprintf(
+							'Repository yielded non-Document %s as version of Document %s - unsupported repository response',
+							$document->getId(),
+							$this->getId()
+						)
+					);
                 }
                 $result[] = $document;
             }

--- a/src/VersioningServiceInterface.php
+++ b/src/VersioningServiceInterface.php
@@ -32,7 +32,7 @@ interface VersioningServiceInterface
      * @param string $objectId the identifier for the PWC
      * @param ExtensionDataInterface|null $extension
      */
-    public function cancelCheckOut($repositoryId, $objectId, ExtensionDataInterface $extension = null);
+    public function cancelCheckOut($repositoryId, & $objectId, ExtensionDataInterface $extension = null);
 
     /**
      * Checks-in the private working copy (PWC) document.
@@ -51,10 +51,11 @@ interface VersioningServiceInterface
      * @param AclInterface|null $addAces a list of ACEs that must be added to the newly created document object
      * @param AclInterface|null $removeAces a list of ACEs that must be removed from the newly created document object
      * @param ExtensionDataInterface|null $extension
+	 * @return string|null Versioned object ID of original source if succesful, null otherwise
      */
     public function checkIn(
         $repositoryId,
-        $objectId,
+        & $objectId,
         $major = true,
         PropertiesInterface $properties = null,
         StreamInterface $contentStream = null,
@@ -74,6 +75,7 @@ interface VersioningServiceInterface
      * @param ExtensionDataInterface|null $extension
      * @param boolean|null $contentCopied output: indicator if the content of the original
      *      document has been copied to the PWC
+	 * @return string|null Versioned object ID of PWC if succesful, null otherwise
      */
     public function checkOut(
         $repositoryId,


### PR DESCRIPTION
Adds needed support for:
- Check-in
- Check-out
- Cancel checked-out
- Get all versions
- Get latest version
- Get latest version's properties

Changes VersioningServiceInterface to make checkIn() and checkOut() return values.
