### PR TITLE
Change property name Choice->choice to Choice->choices

### DIFF
--- a/src/DataObjects/Choice.php
+++ b/src/DataObjects/Choice.php
@@ -33,26 +33,26 @@ class Choice implements ChoiceInterface
     /**
      * @var ChoiceInterface[]
      */
-    protected $choice = array();
+    protected $choices = array();
 
     /**
      * @return ChoiceInterface[]
      */
-    public function getChoice()
+    public function getChoices()
     {
-        return $this->choice;
+        return $this->choices;
     }
 
     /**
-     * @param ChoiceInterface[] $choice
+     * @param ChoiceInterface[] $choices
      */
-    public function setChoice(array $choice)
+    public function setChoices(array $choices)
     {
-        foreach ($choice as $value) {
+        foreach ($choices as $value) {
             $this->checkType('\\Dkd\\PhpCmis\\Definitions\\ChoiceInterface', $value);
         }
 
-        $this->choice = $choice;
+        $this->choices = $choices;
     }
 
     /**

--- a/src/Definitions/ChoiceInterface.php
+++ b/src/Definitions/ChoiceInterface.php
@@ -18,12 +18,12 @@ interface ChoiceInterface
     /**
      * @return ChoiceInterface[]
      */
-    public function getChoice();
+    public function getChoices();
 
     /**
      * @param ChoiceInterface[] $choice
      */
-    public function setChoice(array $choice);
+    public function setChoices(array $choice);
 
     /**
      * Return the display name of the choice value.

--- a/tests/Unit/DataObjects/ChoiceTest.php
+++ b/tests/Unit/DataObjects/ChoiceTest.php
@@ -30,8 +30,8 @@ class ChoiceTest extends \PHPUnit_Framework_TestCase
     {
         /** @var ChoiceInterface $choice */
         $choice = $this->getMockForAbstractClass(self::CLASS_TO_TEST);
-        $this->choice->setChoice(array($choice));
-        $this->assertAttributeEquals(array($choice), 'choice', $this->choice);
+        $this->choice->setChoices(array($choice));
+        $this->assertAttributeEquals(array($choice), 'choices', $this->choice);
     }
 
     public function testSetChoiceThrowsExceptionIfChoiceListContainsInvalidValue()
@@ -39,18 +39,18 @@ class ChoiceTest extends \PHPUnit_Framework_TestCase
         /** @var ChoiceInterface $choice */
         $choice = $this->getMockForAbstractClass(self::CLASS_TO_TEST);
         $this->setExpectedException('\\Dkd\\PhpCmis\\Exception\\CmisInvalidArgumentException', '', 1413440336);
-        $this->choice->setChoice(array($choice, new \stdClass()));
+        $this->choice->setChoices(array($choice, new \stdClass()));
     }
 
     /**
      * @depends testSetChoiceSetsPropertyValue
      */
-    public function testGetChoiceGetsPropertyValue()
+    public function testGetChoicesGetsPropertyValue()
     {
         $choice = $this->getMockForAbstractClass(self::CLASS_TO_TEST);
-        $this->choice->setChoice(array($choice));
+        $this->choice->setChoices(array($choice));
 
-        $this->assertEquals(array($choice), $this->choice->getChoice());
+        $this->assertEquals(array($choice), $this->choice->getChoices());
     }
 
     public function testSetDisplayNameSetsPropertyValue()


### PR DESCRIPTION
Method and attribute accepts an array of multiple choices. For consistency with singular/plural we rename the method to the proper naming "choices".

Related: https://github.com/dkd/php-cmis-client/pull/14
