### PR TITLE
Disable exceptions from 32bit php integer/double conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,14 @@ Currently implemented Services
   - [ ] applyACL
 
 
+32/64-bit
+=======
+  The library is mainly targeting 64-bit environments. 32-bit should work, but no extensive testing is done.
+
 LICENSE
 =======
-   Copyright 2014 Sascha Egerer - dkd Internet Service GmbH <http://www.dkd.de>
+   Copyright 2014-2015 Sascha Egerer - dkd Internet Service GmbH <http://www.dkd.de>
+   Copyright 2015-2016 Johannes Goslar, Claus Due - dkd Internet Service GmbH <http://www.dkd.de>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/Converter/AbstractDataConverter.php
+++ b/src/Converter/AbstractDataConverter.php
@@ -96,6 +96,10 @@ abstract class AbstractDataConverter implements DataConverterInterface
             // DateTimes are given in a Timestamp with milliseconds.
             // see http://docs.oasis-open.org/cmis/CMIS/v1.1/os/CMIS-v1.1-os.html#x1-5420004
             $date->setTimestamp($source / 1000);
+        } elseif (PHP_INT_SIZE == 4 && is_double($source)) {
+            //TODO: 32-bit - handle this specially?
+            $date = new \DateTime();
+            $date->setTimestamp($source / 1000);
         } elseif (is_string($source)) {
             try {
                 $date = new \DateTime($source);

--- a/src/DataObjects/PropertyInteger.php
+++ b/src/DataObjects/PropertyInteger.php
@@ -24,9 +24,16 @@ class PropertyInteger extends AbstractPropertyData implements MutablePropertyInt
      */
     public function setValues(array $values)
     {
-        foreach ($values as $value) {
+
+        foreach ($values as & $value) {
+            if (PHP_INT_SIZE == 4 && is_double($value)) {
+                //TODO: 32bit - handle this specially?
+                $value = $this->castValueToSimpleType('integer', $value);
+            }
+
             $this->checkType('integer', $value, true);
         }
+
         parent::setValues($values);
     }
 }

--- a/src/Traits/TypeHelperTrait.php
+++ b/src/Traits/TypeHelperTrait.php
@@ -68,16 +68,21 @@ trait TypeHelperTrait
         try {
             $this->checkType($expectedType, $value, $nullIsValidValue);
         } catch (CmisInvalidArgumentException $exception) {
-            trigger_error(
-                sprintf(
-                    'Given value is of type "%s" but a value of type "%s" was expected.'
-                    . ' Value has been casted to the expected type.',
-                    gettype($value),
-                    $expectedType
-                ),
-                E_USER_NOTICE
-            );
-            settype($value, $expectedType);
+            if (PHP_INT_SIZE == 4 && $expectedType == 'integer' && is_double($value)) {
+                //TODO: 32bit - handle this specially?
+                settype($value, $expectedType);
+            } else {
+                trigger_error(
+                    sprintf(
+                        'Given value is of type "%s" but a value of type "%s" was expected.'
+                        . ' Value has been casted to the expected type.',
+                        gettype($value),
+                        $expectedType
+                    ),
+                    E_USER_NOTICE
+                );
+                settype($value, $expectedType);
+            }
         }
 
         return $value;

--- a/tests/Unit/DataObjects/PropertyIntegerTest.php
+++ b/tests/Unit/DataObjects/PropertyIntegerTest.php
@@ -38,7 +38,7 @@ class PropertyIntegerTest extends \PHPUnit_Framework_TestCase
             $expected = $value;
         }
 
-        if (!is_integer($value) && $value !== null) {
+        if (!is_integer($value) && $value !== null && !(PHP_INT_SIZE == 4 && is_double($value))) {
             $this->setExpectedException('\\Dkd\\PhpCmis\\Exception\\CmisInvalidArgumentException', '', 1413440336);
         }
 
@@ -57,7 +57,7 @@ class PropertyIntegerTest extends \PHPUnit_Framework_TestCase
             $expected = $value;
         }
 
-        if (!is_integer($value) && $value !== null) {
+        if (!is_integer($value) && $value !== null && !(PHP_INT_SIZE == 4 && is_double($value))) {
             $this->setExpectedException('\\Dkd\\PhpCmis\\Exception\\CmisInvalidArgumentException', '', 1413440336);
         }
 

--- a/tests/Unit/Traits/TypeHelperTraitTest.php
+++ b/tests/Unit/Traits/TypeHelperTraitTest.php
@@ -172,6 +172,12 @@ class TypeHelperTraitTest extends \PHPUnit_Framework_TestCase
         $value,
         $errorNoticeMessageExpected
     ) {
+        if (PHP_INT_SIZE == 4) {
+            //TODO: 32bit - handle this specially?
+            //we might get doubles instead of values at other points, thus the notification is disabled
+            return;
+        }
+
         if ($errorNoticeMessageExpected) {
             $this->setExpectedException('\\PHPUnit_Framework_Error_Notice');
         }


### PR DESCRIPTION
#13

Unsure about all implications on 32-bit with this.
Should not change anything on 64-bit.
units and examples are running and transmitting int values.
