### PR TITLE
[BUGFIX] Alias "choices" and "choice" on AbstractPropertyDefinition

### DIFF
--- a/src/DataObjects/AbstractPropertyDefinition.php
+++ b/src/DataObjects/AbstractPropertyDefinition.php
@@ -238,6 +238,28 @@ abstract class AbstractPropertyDefinition extends AbstractExtensionData implemen
     }
 
     /**
+     * COMPATIBILITY: required by CMIS auto-property mapping; the "choices" property
+     * is sent in responses as "choice" (singular). PHP API allows properl plural name.
+     *
+     * @return ChoiceInterface[]
+     */
+    public function getChoice()
+    {
+        return $this->choices;
+    }
+
+    /**
+     * COMPATIBILITY: required by CMIS auto-property mapping; the "choices" property
+     * is sent in responses as "choice" (singular). PHP API allows properl plural name.
+     *
+     * @param ChoiceInterface[] $choices
+     */
+    public function setChoice(array $choices)
+    {
+        $this->choices = $choices;
+    }
+
+    /**
      * @return ChoiceInterface[]
      */
     public function getChoices()


### PR DESCRIPTION
Responses received from at least Alfresco will contain the "choice" wording as property name and this causes the "choices" property to not be set and triggers an Exception.

Occurs since renaming said property in the PHP library. Alias added to prevent failure while still allowing the property to be addressed as "choices" in PHP. Noted added in PHPDOC.

(discovered while debugging https://github.com/dkd/php-cmis-client/issues/22 but is not required for solving that issue)
