### PR TITLE
[BUGFIX] Use setContentStream for newly uploaded files

### DIFF
--- a/src/Bindings/Browser/ObjectService.php
+++ b/src/Bindings/Browser/ObjectService.php
@@ -196,9 +196,7 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
         if ($versioningState !== null) {
             $queryArray[Constants::PARAM_VERSIONING_STATE] = (string) $versioningState;
         }
-        if ($contentStream) {
-            $queryArray['content'] = $contentStream;
-        }
+
         $responseData = $this->post(
             $url,
             $queryArray
@@ -206,7 +204,17 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
 
         $newObject = $this->getJsonConverter()->convertObject($responseData);
 
-        return ($newObject === null) ? null : $newObject->getId();
+        if ($newObject) {
+            $newObjectId = $newObject->getId();
+            if ($contentStream) {
+                if ($contentStream instanceof PostFile) {
+                    $contentStream = $contentStream->getContent();
+                }
+                $this->setContentStream($repositoryId, $newObjectId, $contentStream);
+            }
+            return $newObjectId;
+        }
+        return null;
     }
 
     /**

--- a/tests/Unit/Bindings/Browser/ObjectServiceTest.php
+++ b/tests/Unit/Bindings/Browser/ObjectServiceTest.php
@@ -213,7 +213,7 @@ class ObjectServiceTest extends AbstractBrowserBindingServiceTestCase
         $objectService = $this->getMockBuilder(self::CLASS_TO_TEST)->setConstructorArgs(
             array($this->getSessionMock(), $cmisBindingsHelperMock)
         )->setMethods(
-            array('getObjectUrl', 'getRepositoryUrl', 'post')
+            array('getObjectUrl', 'getRepositoryUrl', 'post', 'setContentStream')
         )->getMock();
 
         if ($folderId === null) {
@@ -228,7 +228,10 @@ class ObjectServiceTest extends AbstractBrowserBindingServiceTestCase
         }
 
         if ($expectedContentStream) {
-            $expectedPostData['content'] = $expectedContentStream;
+            $objectService->expects($this->once())->method('setContentStream')
+                ->with($repositoryId, 'foo-id', $this->anything());
+        } else {
+            $objectService->expects($this->never())->method('setContentStream');
         }
         $objectService->expects($this->atLeastOnce())->method('post')->with(
             $expectedUrl,


### PR DESCRIPTION
Due to the way posting file bodies works when combined with a query array, files with unicode names would receive an incorrect (latin1 variant) file name.

In order to avoid this happening, the file upload itself now gets performed in a separate request which posts only the file. Doing this lets the original createDocument call set the correct title first and it does not get a bad encoding after setting the file contents.

It is possible there is a more appropriate way to fix this (e.g. in PostFile settings) but I have not been able to find it. It seems to be caused by some detection on the CMIS server side and I've found no request flags that would seem to control it. Headers of the posted request appear to be the same when using either strategy.

This patch solves the issue for now and can easily be reverted / improved if a better way comes up.

Close: #22
