### PR TITLE
Fix phpdoc

### DIFF
--- a/src/AclServiceInterface.php
+++ b/src/AclServiceInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *
@@ -14,6 +14,9 @@ use Dkd\PhpCmis\Data\AclInterface;
 use Dkd\PhpCmis\Data\ExtensionDataInterface;
 use Dkd\PhpCmis\Enum\AclPropagation;
 
+/**
+ * Interface AclServiceInterface
+ */
 interface AclServiceInterface
 {
     /**

--- a/src/Bindings/BindingSessionInterface.php
+++ b/src/Bindings/BindingSessionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Bindings/Browser/AbstractBrowserBindingService.php
+++ b/src/Bindings/Browser/AbstractBrowserBindingService.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings\Browser;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *
@@ -36,6 +36,7 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Stream\StreamInterface;
 use GuzzleHttp\Exception\RequestException;
 use League\Url\Url;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Base class for all Browser Binding client services.
@@ -412,7 +413,7 @@ abstract class AbstractBrowserBindingService implements LinkAccessInterface
      * @param Url $url Request url
      * @param resource|string|StreamInterface|array $content Entity body data or an array for POST fields and files
      * @param array $headers Additional header options
-     * @return Response
+     * @return ResponseInterface
      * @throws CmisBaseException an more specific exception of this type could be thrown. For more details see
      * @see AbstractBrowserBindingService::convertStatusCode()
      */

--- a/src/Bindings/Browser/AclService.php
+++ b/src/Bindings/Browser/AclService.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings\Browser;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Bindings/Browser/CmisBrowserBinding.php
+++ b/src/Bindings/Browser/CmisBrowserBinding.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings\Browser;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Bindings/Browser/DiscoveryService.php
+++ b/src/Bindings/Browser/DiscoveryService.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings\Browser;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Bindings/Browser/JSONConstants.php
+++ b/src/Bindings/Browser/JSONConstants.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings\Browser;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Bindings/Browser/MultiFilingService.php
+++ b/src/Bindings/Browser/MultiFilingService.php
@@ -2,7 +2,7 @@
 namespace Dkd\PhpCmis\Bindings\Browser;
 
 /**
- * This file is part of php-cmis-lib.
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *
@@ -14,7 +14,7 @@ use Dkd\PhpCmis\Constants;
 use Dkd\PhpCmis\Data\ExtensionDataInterface;
 use Dkd\PhpCmis\MultiFilingServiceInterface;
 
-/**
+/*
  * MultiFiling Service Browser Binding client.
  */
 class MultiFilingService extends AbstractBrowserBindingService implements MultiFilingServiceInterface

--- a/src/Bindings/Browser/NavigationService.php
+++ b/src/Bindings/Browser/NavigationService.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings\Browser;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Bindings/Browser/ObjectService.php
+++ b/src/Bindings/Browser/ObjectService.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings\Browser;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Bindings/Browser/PolicyService.php
+++ b/src/Bindings/Browser/PolicyService.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings\Browser;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Bindings/Browser/RelationshipService.php
+++ b/src/Bindings/Browser/RelationshipService.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings\Browser;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Bindings/Browser/RepositoryService.php
+++ b/src/Bindings/Browser/RepositoryService.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings\Browser;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Bindings/Browser/RepositoryUrlCache.php
+++ b/src/Bindings/Browser/RepositoryUrlCache.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings\Browser;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Bindings/Browser/VersioningService.php
+++ b/src/Bindings/Browser/VersioningService.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings\Browser;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Bindings/CmisBinding.php
+++ b/src/Bindings/CmisBinding.php
@@ -1,6 +1,15 @@
 <?php
 namespace Dkd\PhpCmis\Bindings;
 
+/*
+ * This file is part of php-cmis-client.
+ *
+ * (c) Sascha Egerer <sascha.egerer@dkd.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Dkd\Enumeration\Exception\InvalidEnumerationValueException;
 use Dkd\PhpCmis\AclServiceInterface;
 use Dkd\PhpCmis\Bindings\Browser\RepositoryService;
@@ -21,12 +30,7 @@ use Dkd\PhpCmis\SessionParameter;
 use Doctrine\Common\Cache\Cache;
 
 /**
- * This file is part of php-cmis-lib.
- *
- * (c) Sascha Egerer <sascha.egerer@dkd.de>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+ * Class CmisBinding
  */
 class CmisBinding implements CmisBindingInterface
 {

--- a/src/Bindings/CmisBindingFactory.php
+++ b/src/Bindings/CmisBindingFactory.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Bindings/CmisBindingInterface.php
+++ b/src/Bindings/CmisBindingInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Bindings/CmisBindingsHelper.php
+++ b/src/Bindings/CmisBindingsHelper.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Bindings/CmisInterface.php
+++ b/src/Bindings/CmisInterface.php
@@ -1,14 +1,15 @@
 <?php
 namespace Dkd\PhpCmis\Bindings;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 use Dkd\PhpCmis\AclServiceInterface;
 use Dkd\PhpCmis\DiscoveryServiceInterface;
 use Dkd\PhpCmis\MultiFilingServiceInterface;

--- a/src/Bindings/LinkAccessInterface.php
+++ b/src/Bindings/LinkAccessInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Bindings/Session.php
+++ b/src/Bindings/Session.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Bindings;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/ChangeEventInterface.php
+++ b/src/ChangeEventInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/ChangeEventsInterface.php
+++ b/src/ChangeEventsInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/CmisObject/CmisObjectInterface.php
+++ b/src/CmisObject/CmisObjectInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\CmisObject;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/CmisObject/CmisObjectPropertiesInterface.php
+++ b/src/CmisObject/CmisObjectPropertiesInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\CmisObject;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Converter/AbstractDataConverter.php
+++ b/src/Converter/AbstractDataConverter.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Converter;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Converter/DataConverterInterface.php
+++ b/src/Converter/DataConverterInterface.php
@@ -1,6 +1,15 @@
 <?php
 namespace Dkd\PhpCmis\Converter;
 
+/*
+ * This file is part of php-cmis-client.
+ *
+ * (c) Sascha Egerer \sascha.egerer@dkd.de\
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Dkd\PhpCmis\Data\AclCapabilitiesInterface;
 use Dkd\PhpCmis\Data\AclInterface;
 use Dkd\PhpCmis\Data\AllowableActionsInterface;
@@ -25,12 +34,7 @@ use Dkd\PhpCmis\Definitions\TypeDefinitionInterface;
 use Dkd\PhpCmis\Definitions\TypeDefinitionListInterface;
 
 /**
- * This file is part of php-cmis-lib.
- *
- * (c) Sascha Egerer \sascha.egerer@dkd.de\
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+ * Interface DataConverterInterface
  */
 interface DataConverterInterface
 {
@@ -209,7 +213,7 @@ interface DataConverterInterface
      * @return AclCapabilitiesInterface
      */
     public function convertAclCapabilities(array $data = null);
-    
+
     /**
      * Convert given input data to a TypeDefinition object
      *
@@ -217,7 +221,7 @@ interface DataConverterInterface
      * @return TypeDefinitionInterface
      */
     public function convertTypeDefinition(array $data = null);
-    
+
     /**
      * Convert given input data to a PropertyDefinition object
      *
@@ -225,7 +229,7 @@ interface DataConverterInterface
      * @return PropertyDefinitionInterface
      */
     public function convertPropertyDefinition(array $data = null);
-    
+
     /**
      * Convert given input data to a TypeChildren object
      *
@@ -233,7 +237,7 @@ interface DataConverterInterface
      * @return TypeDefinitionListInterface
      */
     public function convertTypeChildren(array $data = null);
-    
+
     /**
      * Convert given input data to a TypeDescendants object
      *
@@ -241,7 +245,7 @@ interface DataConverterInterface
      * @return TypeDefinitionContainerInterface[]
      */
     public function convertTypeDescendants(array $data = null);
-    
+
     /**
      * Convert given input data to a ObjectData object
      *

--- a/src/Converter/JsonConverter.php
+++ b/src/Converter/JsonConverter.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Converter;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Converter/Types/Definitions/TypeMutabilityInterfaceConverter.php
+++ b/src/Converter/Types/Definitions/TypeMutabilityInterfaceConverter.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Converter\Types\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Converter/Types/Dkd/Enumeration/EnumerationConverter.php
+++ b/src/Converter/Types/Dkd/Enumeration/EnumerationConverter.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Converter\Types\Dkd\Enumeration;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Converter/Types/TypeConverterInterface.php
+++ b/src/Converter/Types/TypeConverterInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Converter\Types;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/AceInterface.php
+++ b/src/Data/AceInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/AclCapabilitiesInterface.php
+++ b/src/Data/AclCapabilitiesInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/AclInterface.php
+++ b/src/Data/AclInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/AllowableActionsInterface.php
+++ b/src/Data/AllowableActionsInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/BindingsObjectFactoryInterface.php
+++ b/src/Data/BindingsObjectFactoryInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/BulkUpdateObjectIdAndChangeTokenInterface.php
+++ b/src/Data/BulkUpdateObjectIdAndChangeTokenInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/ChangeEventInfoInterface.php
+++ b/src/Data/ChangeEventInfoInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/CmisExtensionElementInterface.php
+++ b/src/Data/CmisExtensionElementInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/ContentStreamHashInterface.php
+++ b/src/Data/ContentStreamHashInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/CreatablePropertyTypesInterface.php
+++ b/src/Data/CreatablePropertyTypesInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/DocumentInterface.php
+++ b/src/Data/DocumentInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/DocumentPropertiesInterface.php
+++ b/src/Data/DocumentPropertiesInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/DocumentTypeInterface.php
+++ b/src/Data/DocumentTypeInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/ExtensionDataInterface.php
+++ b/src/Data/ExtensionDataInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/ExtensionFeatureInterface.php
+++ b/src/Data/ExtensionFeatureInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/FailedToDeleteDataInterface.php
+++ b/src/Data/FailedToDeleteDataInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/FileableCmisObjectInterface.php
+++ b/src/Data/FileableCmisObjectInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/FolderInterface.php
+++ b/src/Data/FolderInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/FolderPropertiesInterface.php
+++ b/src/Data/FolderPropertiesInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/FolderTypeInterface.php
+++ b/src/Data/FolderTypeInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/ItemInterface.php
+++ b/src/Data/ItemInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/ItemTypeInterface.php
+++ b/src/Data/ItemTypeInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/MutableAceInterface.php
+++ b/src/Data/MutableAceInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/MutableAclInterface.php
+++ b/src/Data/MutableAclInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/MutablePropertyBooleanInterface.php
+++ b/src/Data/MutablePropertyBooleanInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/MutablePropertyDataInterface.php
+++ b/src/Data/MutablePropertyDataInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/MutablePropertyDateTimeInterface.php
+++ b/src/Data/MutablePropertyDateTimeInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/MutablePropertyDecimalInterface.php
+++ b/src/Data/MutablePropertyDecimalInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/MutablePropertyHtmlInterface.php
+++ b/src/Data/MutablePropertyHtmlInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/MutablePropertyIdInterface.php
+++ b/src/Data/MutablePropertyIdInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/MutablePropertyIntegerInterface.php
+++ b/src/Data/MutablePropertyIntegerInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/MutablePropertyStringInterface.php
+++ b/src/Data/MutablePropertyStringInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/MutablePropertyUriInterface.php
+++ b/src/Data/MutablePropertyUriInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/NewTypeSettableAttributesInterface.php
+++ b/src/Data/NewTypeSettableAttributesInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/ObjectDataInterface.php
+++ b/src/Data/ObjectDataInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/ObjectIdInterface.php
+++ b/src/Data/ObjectIdInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *
@@ -10,6 +10,9 @@ namespace Dkd\PhpCmis\Data;
  * file that was distributed with this source code.
  */
 
+/**
+ * Interface ObjectIdInterface
+ */
 interface ObjectIdInterface
 {
     /**

--- a/src/Data/ObjectInFolderContainerInterface.php
+++ b/src/Data/ObjectInFolderContainerInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/ObjectInFolderDataInterface.php
+++ b/src/Data/ObjectInFolderDataInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/ObjectInFolderListInterface.php
+++ b/src/Data/ObjectInFolderListInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/ObjectListInterface.php
+++ b/src/Data/ObjectListInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/ObjectParentDataInterface.php
+++ b/src/Data/ObjectParentDataInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/ObjectTypeInterface.php
+++ b/src/Data/ObjectTypeInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/PermissionMappingInterface.php
+++ b/src/Data/PermissionMappingInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/PolicyIdListInterface.php
+++ b/src/Data/PolicyIdListInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/PolicyInterface.php
+++ b/src/Data/PolicyInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/PolicyPropertiesInterface.php
+++ b/src/Data/PolicyPropertiesInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/PolicyTypeInterface.php
+++ b/src/Data/PolicyTypeInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/PropertiesInterface.php
+++ b/src/Data/PropertiesInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/PropertyBooleanInterface.php
+++ b/src/Data/PropertyBooleanInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/PropertyDataInterface.php
+++ b/src/Data/PropertyDataInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/PropertyDateTimeInterface.php
+++ b/src/Data/PropertyDateTimeInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/PropertyDecimalInterface.php
+++ b/src/Data/PropertyDecimalInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/PropertyHtmlInterface.php
+++ b/src/Data/PropertyHtmlInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/PropertyIdInterface.php
+++ b/src/Data/PropertyIdInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/PropertyIntegerInterface.php
+++ b/src/Data/PropertyIntegerInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/PropertyInterface.php
+++ b/src/Data/PropertyInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/PropertyStringInterface.php
+++ b/src/Data/PropertyStringInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/PropertyUriInterface.php
+++ b/src/Data/PropertyUriInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/RelationshipInterface.php
+++ b/src/Data/RelationshipInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/RelationshipPropertiesInterface.php
+++ b/src/Data/RelationshipPropertiesInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/RelationshipTypeInterface.php
+++ b/src/Data/RelationshipTypeInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/RenditionDataInterface.php
+++ b/src/Data/RenditionDataInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/RenditionInterface.php
+++ b/src/Data/RenditionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/RepositoryCapabilitiesInterface.php
+++ b/src/Data/RepositoryCapabilitiesInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/RepositoryInfoInterface.php
+++ b/src/Data/RepositoryInfoInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Data/SecondaryTypeInterface.php
+++ b/src/Data/SecondaryTypeInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Data;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/AbstractCmisObject.php
+++ b/src/DataObjects/AbstractCmisObject.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *
@@ -40,6 +40,9 @@ use Dkd\PhpCmis\OperationContextInterface;
 use Dkd\PhpCmis\PropertyIds;
 use Dkd\PhpCmis\SessionInterface;
 
+/**
+ * Class AbstractCmisObject
+ */
 abstract class AbstractCmisObject implements CmisObjectInterface
 {
     /**

--- a/src/DataObjects/AbstractExtensionData.php
+++ b/src/DataObjects/AbstractExtensionData.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/AbstractFileableCmisObject.php
+++ b/src/DataObjects/AbstractFileableCmisObject.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/AbstractPropertyData.php
+++ b/src/DataObjects/AbstractPropertyData.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/AbstractPropertyDefinition.php
+++ b/src/DataObjects/AbstractPropertyDefinition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/AbstractTypeDefinition.php
+++ b/src/DataObjects/AbstractTypeDefinition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/AccessControlEntry.php
+++ b/src/DataObjects/AccessControlEntry.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/AccessControlList.php
+++ b/src/DataObjects/AccessControlList.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/AclCapabilities.php
+++ b/src/DataObjects/AclCapabilities.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/AllowableActions.php
+++ b/src/DataObjects/AllowableActions.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/BindingsObjectFactory.php
+++ b/src/DataObjects/BindingsObjectFactory.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/ChangeEventInfo.php
+++ b/src/DataObjects/ChangeEventInfo.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/Choice.php
+++ b/src/DataObjects/Choice.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/CmisExtensionElement.php
+++ b/src/DataObjects/CmisExtensionElement.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/CreatablePropertyTypes.php
+++ b/src/DataObjects/CreatablePropertyTypes.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/Document.php
+++ b/src/DataObjects/Document.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/DocumentType.php
+++ b/src/DataObjects/DocumentType.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/DocumentTypeDefinition.php
+++ b/src/DataObjects/DocumentTypeDefinition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/ExtensionFeature.php
+++ b/src/DataObjects/ExtensionFeature.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/FailedToDeleteData.php
+++ b/src/DataObjects/FailedToDeleteData.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/Folder.php
+++ b/src/DataObjects/Folder.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/FolderType.php
+++ b/src/DataObjects/FolderType.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/FolderTypeDefinition.php
+++ b/src/DataObjects/FolderTypeDefinition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/Item.php
+++ b/src/DataObjects/Item.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/ItemType.php
+++ b/src/DataObjects/ItemType.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/ItemTypeDefinition.php
+++ b/src/DataObjects/ItemTypeDefinition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/NewTypeSettableAttributes.php
+++ b/src/DataObjects/NewTypeSettableAttributes.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/ObjectData.php
+++ b/src/DataObjects/ObjectData.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/ObjectId.php
+++ b/src/DataObjects/ObjectId.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/ObjectInFolderContainer.php
+++ b/src/DataObjects/ObjectInFolderContainer.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
  *

--- a/src/DataObjects/ObjectInFolderData.php
+++ b/src/DataObjects/ObjectInFolderData.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
  *

--- a/src/DataObjects/ObjectInFolderList.php
+++ b/src/DataObjects/ObjectInFolderList.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
  *

--- a/src/DataObjects/ObjectList.php
+++ b/src/DataObjects/ObjectList.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
  *

--- a/src/DataObjects/ObjectParentData.php
+++ b/src/DataObjects/ObjectParentData.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
  *

--- a/src/DataObjects/ObjectTypeHelperTrait.php
+++ b/src/DataObjects/ObjectTypeHelperTrait.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PermissionDefinition.php
+++ b/src/DataObjects/PermissionDefinition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PermissionMapping.php
+++ b/src/DataObjects/PermissionMapping.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/Policy.php
+++ b/src/DataObjects/Policy.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PolicyIdList.php
+++ b/src/DataObjects/PolicyIdList.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PolicyType.php
+++ b/src/DataObjects/PolicyType.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PolicyTypeDefinition.php
+++ b/src/DataObjects/PolicyTypeDefinition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/Principal.php
+++ b/src/DataObjects/Principal.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/Properties.php
+++ b/src/DataObjects/Properties.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/Property.php
+++ b/src/DataObjects/Property.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PropertyBoolean.php
+++ b/src/DataObjects/PropertyBoolean.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PropertyBooleanDefinition.php
+++ b/src/DataObjects/PropertyBooleanDefinition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PropertyDateTime.php
+++ b/src/DataObjects/PropertyDateTime.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PropertyDateTimeDefinition.php
+++ b/src/DataObjects/PropertyDateTimeDefinition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PropertyDecimal.php
+++ b/src/DataObjects/PropertyDecimal.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PropertyDecimalDefinition.php
+++ b/src/DataObjects/PropertyDecimalDefinition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PropertyHtml.php
+++ b/src/DataObjects/PropertyHtml.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PropertyHtmlDefinition.php
+++ b/src/DataObjects/PropertyHtmlDefinition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PropertyId.php
+++ b/src/DataObjects/PropertyId.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PropertyIdDefinition.php
+++ b/src/DataObjects/PropertyIdDefinition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PropertyInteger.php
+++ b/src/DataObjects/PropertyInteger.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PropertyIntegerDefinition.php
+++ b/src/DataObjects/PropertyIntegerDefinition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PropertyString.php
+++ b/src/DataObjects/PropertyString.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PropertyStringDefinition.php
+++ b/src/DataObjects/PropertyStringDefinition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PropertyUri.php
+++ b/src/DataObjects/PropertyUri.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/PropertyUriDefinition.php
+++ b/src/DataObjects/PropertyUriDefinition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/Relationship.php
+++ b/src/DataObjects/Relationship.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/RelationshipType.php
+++ b/src/DataObjects/RelationshipType.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/RelationshipTypeDefinition.php
+++ b/src/DataObjects/RelationshipTypeDefinition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/Rendition.php
+++ b/src/DataObjects/Rendition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
  *

--- a/src/DataObjects/RenditionData.php
+++ b/src/DataObjects/RenditionData.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/RepositoryCapabilities.php
+++ b/src/DataObjects/RepositoryCapabilities.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/RepositoryInfo.php
+++ b/src/DataObjects/RepositoryInfo.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/RepositoryInfoBrowserBinding.php
+++ b/src/DataObjects/RepositoryInfoBrowserBinding.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/SecondaryType.php
+++ b/src/DataObjects/SecondaryType.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/SecondaryTypeDefinition.php
+++ b/src/DataObjects/SecondaryTypeDefinition.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/TypeDefinitionContainer.php
+++ b/src/DataObjects/TypeDefinitionContainer.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/TypeDefinitionList.php
+++ b/src/DataObjects/TypeDefinitionList.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DataObjects/TypeMutability.php
+++ b/src/DataObjects/TypeMutability.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\DataObjects;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/ChoiceInterface.php
+++ b/src/Definitions/ChoiceInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/DocumentTypeDefinitionInterface.php
+++ b/src/Definitions/DocumentTypeDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/FolderTypeDefinitionInterface.php
+++ b/src/Definitions/FolderTypeDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/ItemTypeDefinitionInterface.php
+++ b/src/Definitions/ItemTypeDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/MutableDocumentTypeDefinitionInterface.php
+++ b/src/Definitions/MutableDocumentTypeDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/MutableFolderTypeDefinitionInterface.php
+++ b/src/Definitions/MutableFolderTypeDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/MutableItemTypeDefinitionInterface.php
+++ b/src/Definitions/MutableItemTypeDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/MutablePolicyTypeDefinitionInterface.php
+++ b/src/Definitions/MutablePolicyTypeDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/MutablePropertyBooleanDefinitionInterface.php
+++ b/src/Definitions/MutablePropertyBooleanDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/MutablePropertyDateTimeDefinitionInterface.php
+++ b/src/Definitions/MutablePropertyDateTimeDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/MutablePropertyDecimalDefinitionInterface.php
+++ b/src/Definitions/MutablePropertyDecimalDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/MutablePropertyDefinitionInterface.php
+++ b/src/Definitions/MutablePropertyDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/MutablePropertyHtmlDefinitionInterface.php
+++ b/src/Definitions/MutablePropertyHtmlDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/MutablePropertyIdDefinitionInterface.php
+++ b/src/Definitions/MutablePropertyIdDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/MutablePropertyIntegerDefinitionInterface.php
+++ b/src/Definitions/MutablePropertyIntegerDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/MutablePropertyStringDefinitionInterface.php
+++ b/src/Definitions/MutablePropertyStringDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/MutablePropertyUriDefinitionInterface.php
+++ b/src/Definitions/MutablePropertyUriDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/MutableRelationshipTypeDefinitionInterface.php
+++ b/src/Definitions/MutableRelationshipTypeDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/MutableSecondaryTypeDefinitionInterface.php
+++ b/src/Definitions/MutableSecondaryTypeDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/MutableTypeDefinitionInterface.php
+++ b/src/Definitions/MutableTypeDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/PermissionDefinitionInterface.php
+++ b/src/Definitions/PermissionDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/PolicyTypeDefinitionInterface.php
+++ b/src/Definitions/PolicyTypeDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/PropertyBooleanDefinitionInterface.php
+++ b/src/Definitions/PropertyBooleanDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/PropertyDateTimeDefinitionInterface.php
+++ b/src/Definitions/PropertyDateTimeDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/PropertyDecimalDefinitionInterface.php
+++ b/src/Definitions/PropertyDecimalDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/PropertyDefinitionInterface.php
+++ b/src/Definitions/PropertyDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/PropertyHtmlDefinitionInterface.php
+++ b/src/Definitions/PropertyHtmlDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/PropertyIdDefinitionInterface.php
+++ b/src/Definitions/PropertyIdDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/PropertyIntegerDefinitionInterface.php
+++ b/src/Definitions/PropertyIntegerDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/PropertyStringDefinitionInterface.php
+++ b/src/Definitions/PropertyStringDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/PropertyUriDefinitionInterface.php
+++ b/src/Definitions/PropertyUriDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/RelationshipTypeDefinitionInterface.php
+++ b/src/Definitions/RelationshipTypeDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/SecondaryTypeDefinitionInterface.php
+++ b/src/Definitions/SecondaryTypeDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/TypeDefinitionContainerInterface.php
+++ b/src/Definitions/TypeDefinitionContainerInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/TypeDefinitionInterface.php
+++ b/src/Definitions/TypeDefinitionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/TypeDefinitionListInterface.php
+++ b/src/Definitions/TypeDefinitionListInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Definitions/TypeMutabilityInterface.php
+++ b/src/Definitions/TypeMutabilityInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Definitions;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/DiscoveryServiceInterface.php
+++ b/src/DiscoveryServiceInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/AclPropagation.php
+++ b/src/Enum/AclPropagation.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/Action.php
+++ b/src/Enum/Action.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/BaseTypeId.php
+++ b/src/Enum/BaseTypeId.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/BindingType.php
+++ b/src/Enum/BindingType.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/CapabilityAcl.php
+++ b/src/Enum/CapabilityAcl.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/CapabilityChanges.php
+++ b/src/Enum/CapabilityChanges.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/CapabilityContentStreamUpdates.php
+++ b/src/Enum/CapabilityContentStreamUpdates.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/CapabilityJoin.php
+++ b/src/Enum/CapabilityJoin.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/CapabilityOrderBy.php
+++ b/src/Enum/CapabilityOrderBy.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/CapabilityQuery.php
+++ b/src/Enum/CapabilityQuery.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/CapabilityRenditions.php
+++ b/src/Enum/CapabilityRenditions.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/Cardinality.php
+++ b/src/Enum/Cardinality.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/ChangeType.php
+++ b/src/Enum/ChangeType.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/CmisVersion.php
+++ b/src/Enum/CmisVersion.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/ContentStreamAllowed.php
+++ b/src/Enum/ContentStreamAllowed.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/DateTimeFormat.php
+++ b/src/Enum/DateTimeFormat.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
  *

--- a/src/Enum/DateTimeResolution.php
+++ b/src/Enum/DateTimeResolution.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/DecimalPrecision.php
+++ b/src/Enum/DecimalPrecision.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/ExtensionLevel.php
+++ b/src/Enum/ExtensionLevel.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/IncludeRelationships.php
+++ b/src/Enum/IncludeRelationships.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/PropertyCheckEnum.php
+++ b/src/Enum/PropertyCheckEnum.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/PropertyType.php
+++ b/src/Enum/PropertyType.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/RelationshipDirection.php
+++ b/src/Enum/RelationshipDirection.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/SupportedPermissions.php
+++ b/src/Enum/SupportedPermissions.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/UnfileObject.php
+++ b/src/Enum/UnfileObject.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/Updatability.php
+++ b/src/Enum/Updatability.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Enum/VersioningState.php
+++ b/src/Enum/VersioningState.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Enum;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/CmisBaseException.php
+++ b/src/Exception/CmisBaseException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/CmisConnectionException.php
+++ b/src/Exception/CmisConnectionException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/CmisConstraintException.php
+++ b/src/Exception/CmisConstraintException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/CmisContentAlreadyExistsException.php
+++ b/src/Exception/CmisContentAlreadyExistsException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/CmisFilterNotValidException.php
+++ b/src/Exception/CmisFilterNotValidException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/CmisInvalidArgumentException.php
+++ b/src/Exception/CmisInvalidArgumentException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/CmisNameConstraintViolationException.php
+++ b/src/Exception/CmisNameConstraintViolationException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/CmisNotSupportedException.php
+++ b/src/Exception/CmisNotSupportedException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/CmisObjectNotFoundException.php
+++ b/src/Exception/CmisObjectNotFoundException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/CmisPermissionDeniedException.php
+++ b/src/Exception/CmisPermissionDeniedException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/CmisProxyAuthenticationException.php
+++ b/src/Exception/CmisProxyAuthenticationException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/CmisRuntimeException.php
+++ b/src/Exception/CmisRuntimeException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/CmisStorageException.php
+++ b/src/Exception/CmisStorageException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/CmisStreamNotSupportedException.php
+++ b/src/Exception/CmisStreamNotSupportedException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/CmisUnauthorizedException.php
+++ b/src/Exception/CmisUnauthorizedException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/CmisUpdateConflictException.php
+++ b/src/Exception/CmisUpdateConflictException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/CmisVersioningException.php
+++ b/src/Exception/CmisVersioningException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Exception/IllegalStateException.php
+++ b/src/Exception/IllegalStateException.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Exception;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/MultiFilingServiceInterface.php
+++ b/src/MultiFilingServiceInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/NavigationServiceInterface.php
+++ b/src/NavigationServiceInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/ObjectFactory.php
+++ b/src/ObjectFactory.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
+/*
  * This file is part of php-cmis-client
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>

--- a/src/ObjectFactoryInterface.php
+++ b/src/ObjectFactoryInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/ObjectServiceInterface.php
+++ b/src/ObjectServiceInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/OperationContext.php
+++ b/src/OperationContext.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/OperationContextInterface.php
+++ b/src/OperationContextInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/PolicyServiceInterface.php
+++ b/src/PolicyServiceInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/PrincipalInterface.php
+++ b/src/PrincipalInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/PropertyIds.php
+++ b/src/PropertyIds.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/QueryResult.php
+++ b/src/QueryResult.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
  *

--- a/src/QueryResultInterface.php
+++ b/src/QueryResultInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/QueryStatement.php
+++ b/src/QueryStatement.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
  *

--- a/src/QueryStatementInterface.php
+++ b/src/QueryStatementInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/RelationshipServiceInterface.php
+++ b/src/RelationshipServiceInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/RepositoryServiceInterface.php
+++ b/src/RepositoryServiceInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/Session.php
+++ b/src/Session.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *
@@ -47,8 +47,6 @@ use GuzzleHttp\Stream\StreamInterface;
 
 /**
  * Class Session
- *
- * @author Sascha Egerer <sascha.egerer@dkd.de>
  */
 class Session implements SessionInterface
 {

--- a/src/SessionFactory.php
+++ b/src/SessionFactory.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *
@@ -15,8 +15,6 @@ use Doctrine\Common\Cache\Cache;
 
 /**
  * Class SessionFactory
- *
- * @author Sascha Egerer <sascha.egerer@dkd.de>
  */
 class SessionFactory implements SessionFactoryInterface
 {

--- a/src/SessionFactoryInterface.php
+++ b/src/SessionFactoryInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/SessionInterface.php
+++ b/src/SessionInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/SessionParameter.php
+++ b/src/SessionParameter.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *
@@ -14,8 +14,6 @@ namespace Dkd\PhpCmis;
  * Session parameter constants.
  *
  * @TODO Add description for all session parameters
- *
- * @author Sascha Egerer <sascha.egerer@dkd.de>
  */
 class SessionParameter
 {

--- a/src/Traits/TypeHelperTrait.php
+++ b/src/Traits/TypeHelperTrait.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis\Traits;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/TreeInterface.php
+++ b/src/TreeInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/src/VersioningServiceInterface.php
+++ b/src/VersioningServiceInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace Dkd\PhpCmis;
 
-/**
- * This file is part of php-cmis-lib.
+/*
+ * This file is part of php-cmis-client.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *

--- a/tests/Fixtures/Php/Bindings/CmisBindingConstructorThrowsException.php
+++ b/tests/Fixtures/Php/Bindings/CmisBindingConstructorThrowsException.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Fixtures\Php\Bindings;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>

--- a/tests/Fixtures/Php/ConstructorThrowsException.php
+++ b/tests/Fixtures/Php/ConstructorThrowsException.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Fixtures\Php;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>

--- a/tests/Fixtures/Php/HttpInvokerConstructorThrowsException.php
+++ b/tests/Fixtures/Php/HttpInvokerConstructorThrowsException.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Fixtures\Php;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>

--- a/tests/Unit/Bindings/Browser/AbstractBrowserBindingServiceTest.php
+++ b/tests/Unit/Bindings/Browser/AbstractBrowserBindingServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\Bindings\Browser;
 
-/**
+/*
  * This file is part of php-cmis-client
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -52,6 +52,9 @@ use GuzzleHttp\Client;
 use League\Url\Url;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class AbstractBrowserBindingServiceTest
+ */
 class AbstractBrowserBindingServiceTest extends AbstractBrowserBindingServiceTestCase
 {
     const CLASS_TO_TEST = AbstractBrowserBindingService::class;

--- a/tests/Unit/Bindings/Browser/AbstractBrowserBindingServiceTestCase.php
+++ b/tests/Unit/Bindings/Browser/AbstractBrowserBindingServiceTestCase.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\Bindings\Browser;
 
-/**
+/*
  * This file is part of php-cmis-client
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -16,6 +16,9 @@ use Dkd\PhpCmis\Test\Unit\FixtureHelperTrait;
 use Dkd\PhpCmis\Test\Unit\ReflectionHelperTrait;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class AbstractBrowserBindingServiceTestCase
+ */
 abstract class AbstractBrowserBindingServiceTestCase extends \PHPUnit_Framework_TestCase
 {
     use ReflectionHelperTrait;

--- a/tests/Unit/Bindings/Browser/CmisBrowserBindingTest.php
+++ b/tests/Unit/Bindings/Browser/CmisBrowserBindingTest.php
@@ -1,15 +1,19 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\Bindings\Browser;
 
-use Dkd\PhpCmis\Bindings\Browser\CmisBrowserBinding;
-
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
+ */
+
+use Dkd\PhpCmis\Bindings\Browser\CmisBrowserBinding;
+
+/**
+ * Class CmisBrowserBindingTest
  */
 class CmisBrowserBindingTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Unit/Bindings/Browser/DiscoveryServiceTest.php
+++ b/tests/Unit/Bindings/Browser/DiscoveryServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\Bindings\Browser;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
@@ -19,6 +19,9 @@ use GuzzleHttp\Psr7\Response;
 use League\Url\Url;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class DiscoveryServiceTest
+ */
 class DiscoveryServiceTest extends AbstractBrowserBindingServiceTestCase
 {
     const CLASS_TO_TEST = DiscoveryService::class;

--- a/tests/Unit/Bindings/Browser/JSONConstantsTest.php
+++ b/tests/Unit/Bindings/Browser/JSONConstantsTest.php
@@ -1,16 +1,19 @@
 <?php
-
 namespace Dkd\PhpCmis\Test\Unit\Bindings\Browser;
 
-use Dkd\PhpCmis\Bindings\Browser\JSONConstants;
-
-/**
+/*
  * This file is part of php-cmis-client
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
+ */
+
+use Dkd\PhpCmis\Bindings\Browser\JSONConstants;
+
+/**
+ * Class JSONConstantsTest
  */
 class JSONConstantsTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Unit/Bindings/Browser/NavigationServiceTest.php
+++ b/tests/Unit/Bindings/Browser/NavigationServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\Bindings\Browser;
 
-/**
+/*
  * This file is part of php-cmis-client
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
@@ -18,6 +18,9 @@ use Dkd\PhpCmis\Enum\IncludeRelationships;
 use League\Url\Url;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class NavigationServiceTest
+ */
 class NavigationServiceTest extends AbstractBrowserBindingServiceTestCase
 {
     const CLASS_TO_TEST = NavigationService::class;

--- a/tests/Unit/Bindings/Browser/ObjectServiceTest.php
+++ b/tests/Unit/Bindings/Browser/ObjectServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\Bindings\Browser;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -35,6 +35,9 @@ use GuzzleHttp\Stream\StreamInterface;
 use League\Url\Url;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class ObjectServiceTest
+ */
 class ObjectServiceTest extends AbstractBrowserBindingServiceTestCase
 {
     const CLASS_TO_TEST = ObjectService::class;

--- a/tests/Unit/Bindings/Browser/RepositoryServiceTest.php
+++ b/tests/Unit/Bindings/Browser/RepositoryServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\Bindings\Browser;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -20,6 +20,9 @@ use GuzzleHttp\Psr7\Response;
 use League\Url\Url;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class RepositoryServiceTest
+ */
 class RepositoryServiceTest extends AbstractBrowserBindingServiceTestCase
 {
     const CLASS_TO_TEST = '\\Dkd\\PhpCmis\\Bindings\\Browser\\RepositoryService';

--- a/tests/Unit/Bindings/Browser/RepositoryUrlCacheTest.php
+++ b/tests/Unit/Bindings/Browser/RepositoryUrlCacheTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\Bindings\Browser;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -14,6 +14,9 @@ use Dkd\PhpCmis\Bindings\Browser\RepositoryUrlCache;
 use Dkd\PhpCmis\Constants;
 use League\Url\Url;
 
+/**
+ * Class RepositoryUrlCacheTest
+ */
 class RepositoryUrlCacheTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Unit/Bindings/CmisBindingFactoryTest.php
+++ b/tests/Unit/Bindings/CmisBindingFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\Bindings;
 
-/**
+/*
  * This file is part of php-cmis-client
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -14,6 +14,9 @@ use Dkd\PhpCmis\Bindings\CmisBindingFactory;
 use Dkd\PhpCmis\SessionParameter;
 use Dkd\PhpCmis\Test\Unit\ReflectionHelperTrait;
 
+/**
+ * Class CmisBindingFactoryTest
+ */
 class CmisBindingFactoryTest extends \PHPUnit_Framework_TestCase
 {
     use ReflectionHelperTrait;

--- a/tests/Unit/Bindings/CmisBindingTest.php
+++ b/tests/Unit/Bindings/CmisBindingTest.php
@@ -1,6 +1,15 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\Bindings;
 
+/*
+ * This file is part of php-cmis-client
+ *
+ * (c) Sascha Egerer <sascha.egerer@dkd.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Dkd\PhpCmis\Bindings\BindingSessionInterface;
 use Dkd\PhpCmis\Bindings\CmisBinding;
 use Dkd\PhpCmis\Bindings\Session;
@@ -9,12 +18,7 @@ use Dkd\PhpCmis\SessionParameter;
 use PHPUnit_Framework_MockObject_MockObject;
 
 /**
- * This file is part of php-cmis-client
- *
- * (c) Sascha Egerer <sascha.egerer@dkd.de>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+ * Class CmisBindingTest
  */
 class CmisBindingTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Unit/Bindings/CmisBindingsHelperTest.php
+++ b/tests/Unit/Bindings/CmisBindingsHelperTest.php
@@ -1,17 +1,21 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\Bindings;
 
-use Dkd\PhpCmis\Bindings\CmisBindingsHelper;
-use Dkd\PhpCmis\Enum\BindingType;
-use Dkd\PhpCmis\SessionParameter;
-
-/**
+/*
  * This file is part of php-cmis-client
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
+ */
+
+use Dkd\PhpCmis\Bindings\CmisBindingsHelper;
+use Dkd\PhpCmis\Enum\BindingType;
+use Dkd\PhpCmis\SessionParameter;
+
+/**
+ * Class CmisBindingsHelperTest
  */
 class CmisBindingsHelperTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Unit/Bindings/SessionTest.php
+++ b/tests/Unit/Bindings/SessionTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\Bindings;
 
-/**
+/*
  * This file is part of php-cmis-client
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\Bindings;
 use Dkd\PhpCmis;
 use Dkd\PhpCmis\Bindings\Session;
 
+/**
+ * Class SessionTest
+ */
 class SessionTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructorCreatesUniqueSessionId()

--- a/tests/Unit/Converter/JsonConverterTest.php
+++ b/tests/Unit/Converter/JsonConverterTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\Converter;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -74,6 +74,9 @@ use Dkd\PhpCmis\Test\Unit\FixtureHelperTrait;
 use Dkd\PhpCmis\Test\Unit\ReflectionHelperTrait;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class JsonConverterTest
+ */
 class JsonConverterTest extends \PHPUnit_Framework_TestCase
 {
     use ReflectionHelperTrait;
@@ -799,7 +802,7 @@ class JsonConverterTest extends \PHPUnit_Framework_TestCase
 
         $expectedDateTimeObject = new \DateTime('2014-11-18 09:37:47');
 
-        $this->assertEquals([$expectedDateTimeObject, $expectedDateTimeObject], $result);
+        $this->assertEquals([0 => $expectedDateTimeObject, 2 => $expectedDateTimeObject], $result);
     }
 
     public function testConvertDateTimeValueThrowsExceptionIfInvalidStringGiven()

--- a/tests/Unit/DataObjects/AbstractCmisObjectTest.php
+++ b/tests/Unit/DataObjects/AbstractCmisObjectTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-client
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>

--- a/tests/Unit/DataObjects/AbstractExtensionDataTest.php
+++ b/tests/Unit/DataObjects/AbstractExtensionDataTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-client
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>

--- a/tests/Unit/DataObjects/AbstractPropertyDataTest.php
+++ b/tests/Unit/DataObjects/AbstractPropertyDataTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-client
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -14,6 +14,9 @@ use Dkd\PhpCmis\DataObjects\AbstractPropertyData;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class AbstractPropertyDataTest
+ */
 class AbstractPropertyDataTest extends \PHPUnit_Framework_TestCase
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/AbstractPropertyDefinitionTest.php
+++ b/tests/Unit/DataObjects/AbstractPropertyDefinitionTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -16,6 +16,9 @@ use Dkd\PhpCmis\Enum\PropertyType;
 use Dkd\PhpCmis\Enum\Updatability;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class AbstractPropertyDefinitionTest
+ */
 class AbstractPropertyDefinitionTest extends \PHPUnit_Framework_TestCase
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/AbstractTypeDefinitionTest.php
+++ b/tests/Unit/DataObjects/AbstractTypeDefinitionTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -15,6 +15,9 @@ use Dkd\PhpCmis\Definitions\PropertyDefinitionInterface;
 use Dkd\PhpCmis\Enum\BaseTypeId;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class AbstractTypeDefinitionTest
+ */
 class AbstractTypeDefinitionTest extends \PHPUnit_Framework_TestCase
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/AccessControlEntryTest.php
+++ b/tests/Unit/DataObjects/AccessControlEntryTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -14,6 +14,9 @@ use Dkd\PhpCmis\DataObjects\AccessControlEntry;
 use Dkd\PhpCmis\PrincipalInterface;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class AccessControlEntryTest
+ */
 class AccessControlEntryTest extends \PHPUnit_Framework_TestCase
 {
 

--- a/tests/Unit/DataObjects/AccessControlListTest.php
+++ b/tests/Unit/DataObjects/AccessControlListTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\AccessControlEntry;
 use Dkd\PhpCmis\DataObjects\AccessControlList;
 
+/**
+ * Class AccessControlListTest
+ */
 class AccessControlListTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Unit/DataObjects/AclCapabilitiesTest.php
+++ b/tests/Unit/DataObjects/AclCapabilitiesTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -14,6 +14,9 @@ use Dkd\PhpCmis\DataObjects\AclCapabilities;
 use Dkd\PhpCmis\Enum\AclPropagation;
 use Dkd\PhpCmis\Enum\SupportedPermissions;
 
+/**
+ * Class AclCapabilitiesTest
+ */
 class AclCapabilitiesTest extends \PHPUnit_Framework_TestCase
 {
 

--- a/tests/Unit/DataObjects/AllowableActionsTest.php
+++ b/tests/Unit/DataObjects/AllowableActionsTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\AllowableActions;
 use Dkd\PhpCmis\Enum\Action;
 
+/**
+ * Class AllowableActionsTest
+ */
 class AllowableActionsTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Unit/DataObjects/BindingsObjectFactoryTest.php
+++ b/tests/Unit/DataObjects/BindingsObjectFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -23,6 +23,9 @@ use Dkd\PhpCmis\DataObjects\PropertyStringDefinition;
 use Dkd\PhpCmis\DataObjects\PropertyUriDefinition;
 use Dkd\PhpCmis\Definitions\PropertyDefinitionInterface;
 
+/**
+ * Class BindingsObjectFactoryTest
+ */
 class BindingsObjectFactoryTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Unit/DataObjects/ChangeEventInfoTest.php
+++ b/tests/Unit/DataObjects/ChangeEventInfoTest.php
@@ -1,16 +1,20 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-use Dkd\PhpCmis\DataObjects\ChangeEventInfo;
-use Dkd\PhpCmis\Enum\ChangeType;
-
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
+ */
+
+use Dkd\PhpCmis\DataObjects\ChangeEventInfo;
+use Dkd\PhpCmis\Enum\ChangeType;
+
+/**
+ * Class ChangeEventInfoTest
  */
 class ChangeEventInfoTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Unit/DataObjects/ChoiceTest.php
+++ b/tests/Unit/DataObjects/ChoiceTest.php
@@ -1,16 +1,20 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-use Dkd\PhpCmis\DataObjects\Choice;
-use Dkd\PhpCmis\Definitions\ChoiceInterface;
-
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
+ */
+
+use Dkd\PhpCmis\DataObjects\Choice;
+use Dkd\PhpCmis\Definitions\ChoiceInterface;
+
+/**
+ * Class ChoiceTest
  */
 class ChoiceTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Unit/DataObjects/CmisExtensionElementTest.php
+++ b/tests/Unit/DataObjects/CmisExtensionElementTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\CmisExtensionElement;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class CmisExtensionElementTest
+ */
 class CmisExtensionElementTest extends \PHPUnit_Framework_TestCase
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/CreatablePropertyTypesTest.php
+++ b/tests/Unit/DataObjects/CreatablePropertyTypesTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\CreatablePropertyTypes;
 use Dkd\PhpCmis\Enum\PropertyType;
 
+/**
+ * Class CreatablePropertyTypesTest
+ */
 class CreatablePropertyTypesTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Unit/DataObjects/DocumentTypeDefinitionTest.php
+++ b/tests/Unit/DataObjects/DocumentTypeDefinitionTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -15,6 +15,9 @@ use Dkd\PhpCmis\DataObjects\RelationshipTypeDefinition;
 use Dkd\PhpCmis\Enum\ContentStreamAllowed;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class DocumentTypeDefinitionTest
+ */
 class DocumentTypeDefinitionTest extends \PHPUnit_Framework_TestCase
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/DocumentTypeTest.php
+++ b/tests/Unit/DataObjects/DocumentTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -15,6 +15,9 @@ use Dkd\PhpCmis\DataObjects\DocumentTypeDefinition;
 use Dkd\PhpCmis\Definitions\DocumentTypeDefinitionInterface;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class DocumentTypeTest
+ */
 class DocumentTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructorSetsSession()

--- a/tests/Unit/DataObjects/ExtensionFeatureTest.php
+++ b/tests/Unit/DataObjects/ExtensionFeatureTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\ExtensionFeature;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class ExtensionFeatureTest
+ */
 class ExtensionFeatureTest extends \PHPUnit_Framework_TestCase
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/FailedToDeleteDataTest.php
+++ b/tests/Unit/DataObjects/FailedToDeleteDataTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -12,6 +12,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
 use Dkd\PhpCmis\DataObjects\FailedToDeleteData;
 
+/**
+ * Class FailedToDeleteDataTest
+ */
 class FailedToDeleteDataTest extends \PHPUnit_Framework_TestCase
 {
     public function testSetIdsSetsIdsPropertyToGivenValue()

--- a/tests/Unit/DataObjects/FolderTypeTest.php
+++ b/tests/Unit/DataObjects/FolderTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -14,6 +14,9 @@ use Dkd\PhpCmis\DataObjects\FolderType;
 use Dkd\PhpCmis\DataObjects\FolderTypeDefinition;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class FolderTypeTest
+ */
 class FolderTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructorSetsSession()

--- a/tests/Unit/DataObjects/ItemTypeTest.php
+++ b/tests/Unit/DataObjects/ItemTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -14,6 +14,9 @@ use Dkd\PhpCmis\DataObjects\ItemType;
 use Dkd\PhpCmis\DataObjects\ItemTypeDefinition;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class ItemTypeTest
+ */
 class ItemTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructorSetsSession()

--- a/tests/Unit/DataObjects/NewTypeSettableAttributesTest.php
+++ b/tests/Unit/DataObjects/NewTypeSettableAttributesTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -12,6 +12,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
 use Dkd\PhpCmis\DataObjects\NewTypeSettableAttributes;
 
+/**
+ * Class NewTypeSettableAttributesTest
+ */
 class NewTypeSettableAttributesTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Unit/DataObjects/ObjectDataTest.php
+++ b/tests/Unit/DataObjects/ObjectDataTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -16,6 +16,9 @@ use Dkd\PhpCmis\DataObjects\PropertyId;
 use Dkd\PhpCmis\Enum\BaseTypeId;
 use Dkd\PhpCmis\PropertyIds;
 
+/**
+ * Class ObjectDataTest
+ */
 class ObjectDataTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Unit/DataObjects/ObjectInFolderContainerTest.php
+++ b/tests/Unit/DataObjects/ObjectInFolderContainerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
@@ -14,6 +14,9 @@ use Dkd\PhpCmis\Data\ObjectInFolderContainerInterface;
 use Dkd\PhpCmis\DataObjects\ObjectInFolderData;
 use Dkd\PhpCmis\DataObjects\ObjectInFolderContainer;
 
+/**
+ * Class ObjectInFolderContainerTest
+ */
 class ObjectInFolderContainerTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Unit/DataObjects/ObjectInFolderDataTest.php
+++ b/tests/Unit/DataObjects/ObjectInFolderDataTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
@@ -12,6 +12,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
 use Dkd\PhpCmis\DataObjects\ObjectInFolderData;
 
+/**
+ * Class ObjectInFolderDataTest
+ */
 class ObjectInFolderDataTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Unit/DataObjects/ObjectInFolderListTest.php
+++ b/tests/Unit/DataObjects/ObjectInFolderListTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\ObjectInFolderData;
 use Dkd\PhpCmis\DataObjects\ObjectInFolderList;
 
+/**
+ * Class ObjectInFolderListTest
+ */
 class ObjectInFolderListTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Unit/DataObjects/ObjectListTest.php
+++ b/tests/Unit/DataObjects/ObjectListTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\Data\ObjectDataInterface;
 use Dkd\PhpCmis\DataObjects\ObjectList;
 
+/**
+ * Class ObjectListTest
+ */
 class ObjectListTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Unit/DataObjects/ObjectParentDataTest.php
+++ b/tests/Unit/DataObjects/ObjectParentDataTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
@@ -12,6 +12,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
 use Dkd\PhpCmis\DataObjects\ObjectParentData;
 
+/**
+ * Class ObjectParentDataTest
+ */
 class ObjectParentDataTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Unit/DataObjects/ObjectTypeHelperTraitTest.php
+++ b/tests/Unit/DataObjects/ObjectTypeHelperTraitTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -16,6 +16,9 @@ use Dkd\PhpCmis\SessionInterface;
 use Dkd\PhpCmis\Test\Unit\ReflectionHelperTrait;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class ObjectTypeHelperTraitTest
+ */
 class ObjectTypeHelperTraitTest extends \PHPUnit_Framework_TestCase
 {
     use ReflectionHelperTrait;

--- a/tests/Unit/DataObjects/PermissionDefinitionTest.php
+++ b/tests/Unit/DataObjects/PermissionDefinitionTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -14,6 +14,9 @@ use Dkd\PhpCmis\DataObjects\PermissionDefinition;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 use PHPUnit_Framework_TestCase;
 
+/**
+ * Class PermissionDefinitionTest
+ */
 class PermissionDefinitionTest extends PHPUnit_Framework_TestCase
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/PermissionMappingTest.php
+++ b/tests/Unit/DataObjects/PermissionMappingTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\PermissionMapping;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class PermissionMappingTest
+ */
 class PermissionMappingTest extends \PHPUnit_Framework_TestCase
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/PolicyIdListTest.php
+++ b/tests/Unit/DataObjects/PolicyIdListTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -12,6 +12,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
 use Dkd\PhpCmis\DataObjects\PolicyIdList;
 
+/**
+ * Class PolicyIdListTest
+ */
 class PolicyIdListTest extends \PHPUnit_Framework_TestCase
 {
 

--- a/tests/Unit/DataObjects/PolicyTypeTest.php
+++ b/tests/Unit/DataObjects/PolicyTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -15,6 +15,9 @@ use Dkd\PhpCmis\DataObjects\PolicyTypeDefinition;
 use Dkd\PhpCmis\Definitions\PolicyTypeDefinitionInterface;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class PolicyTypeTest
+ */
 class PolicyTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructorSetsSession()

--- a/tests/Unit/DataObjects/PrincipalTest.php
+++ b/tests/Unit/DataObjects/PrincipalTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -12,6 +12,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
 use Dkd\PhpCmis\DataObjects\Principal;
 
+/**
+ * Class PrincipalTest
+ */
 class PrincipalTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructorSetsId()

--- a/tests/Unit/DataObjects/PropertiesTest.php
+++ b/tests/Unit/DataObjects/PropertiesTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\Properties;
 use Dkd\PhpCmis\DataObjects\PropertyString;
 
+/**
+ * Class PropertiesTest
+ */
 class PropertiesTest extends \PHPUnit_Framework_TestCase
 {
     public function testAddPropertyAddsProperty()

--- a/tests/Unit/DataObjects/PropertyBooleanDefinitionTest.php
+++ b/tests/Unit/DataObjects/PropertyBooleanDefinitionTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -12,6 +12,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
 use Dkd\PhpCmis\DataObjects\PropertyBooleanDefinition;
 
+/**
+ * Class PropertyBooleanDefinitionTest
+ */
 class PropertyBooleanDefinitionTest extends \PHPUnit_Framework_TestCase
 {
     public function testAssertIsInstanceOfAbstractPropertyDefinition()

--- a/tests/Unit/DataObjects/PropertyBooleanTest.php
+++ b/tests/Unit/DataObjects/PropertyBooleanTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\PropertyBoolean;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class PropertyBooleanTest
+ */
 class PropertyBooleanTest extends \PHPUnit_Framework_TestCase
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/PropertyDateTimeDefinitionTest.php
+++ b/tests/Unit/DataObjects/PropertyDateTimeDefinitionTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\PropertyDateTimeDefinition;
 use Dkd\PhpCmis\Enum\DateTimeResolution;
 
+/**
+ * Class PropertyDateTimeDefinitionTest
+ */
 class PropertyDateTimeDefinitionTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Unit/DataObjects/PropertyDateTimeTest.php
+++ b/tests/Unit/DataObjects/PropertyDateTimeTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\PropertyDateTime;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class PropertyDateTimeTest
+ */
 class PropertyDateTimeTest extends \PHPUnit_Framework_TestCase
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/PropertyDecimalDefinitionTest.php
+++ b/tests/Unit/DataObjects/PropertyDecimalDefinitionTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -14,6 +14,9 @@ use Dkd\PhpCmis\DataObjects\PropertyDecimalDefinition;
 use Dkd\PhpCmis\Enum\DecimalPrecision;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class PropertyDecimalDefinitionTest
+ */
 class PropertyDecimalDefinitionTest extends \PHPUnit_Framework_TestCase
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/PropertyDecimalTest.php
+++ b/tests/Unit/DataObjects/PropertyDecimalTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\PropertyDecimal;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class PropertyDecimalTest
+ */
 class PropertyDecimalTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Unit/DataObjects/PropertyHtmlDefinitionTest.php
+++ b/tests/Unit/DataObjects/PropertyHtmlDefinitionTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -12,6 +12,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
 use Dkd\PhpCmis\DataObjects\PropertyHtmlDefinition;
 
+/**
+ * Class PropertyHtmlDefinitionTest
+ */
 class PropertyHtmlDefinitionTest extends \PHPUnit_Framework_TestCase
 {
     public function testAssertIsInstanceOfAbstractPropertyDefinition()

--- a/tests/Unit/DataObjects/PropertyHtmlTest.php
+++ b/tests/Unit/DataObjects/PropertyHtmlTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\PropertyHtml;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class PropertyHtmlTest
+ */
 class PropertyHtmlTest extends PropertyStringTest
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/PropertyIdDefinitionTest.php
+++ b/tests/Unit/DataObjects/PropertyIdDefinitionTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -12,6 +12,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
 use Dkd\PhpCmis\DataObjects\PropertyIdDefinition;
 
+/**
+ * Class PropertyIdDefinitionTest
+ */
 class PropertyIdDefinitionTest extends \PHPUnit_Framework_TestCase
 {
     public function testAssertIsInstanceOfAbstractPropertyDefinition()

--- a/tests/Unit/DataObjects/PropertyIdTest.php
+++ b/tests/Unit/DataObjects/PropertyIdTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\PropertyId;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class PropertyIdTest
+ */
 class PropertyIdTest extends PropertyStringTest
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/PropertyIntegerTest.php
+++ b/tests/Unit/DataObjects/PropertyIntegerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\PropertyInteger;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class PropertyIntegerTest
+ */
 class PropertyIntegerTest extends \PHPUnit_Framework_TestCase
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/PropertyIntergerDefinitionTest.php
+++ b/tests/Unit/DataObjects/PropertyIntergerDefinitionTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\PropertyIntegerDefinition;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class PropertyIntegerDefinitionTest
+ */
 class PropertyIntegerDefinitionTest extends \PHPUnit_Framework_TestCase
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/PropertyStringDefinitionTest.php
+++ b/tests/Unit/DataObjects/PropertyStringDefinitionTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\PropertyStringDefinition;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class PropertyStringDefinitionTest
+ */
 class PropertyStringDefinitionTest extends \PHPUnit_Framework_TestCase
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/PropertyStringTest.php
+++ b/tests/Unit/DataObjects/PropertyStringTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\PropertyString;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class PropertyStringTest
+ */
 class PropertyStringTest extends \PHPUnit_Framework_TestCase
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/PropertyUriDefinitionTest.php
+++ b/tests/Unit/DataObjects/PropertyUriDefinitionTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -12,6 +12,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
 use Dkd\PhpCmis\DataObjects\PropertyUriDefinition;
 
+/**
+ * Class PropertyUriDefinitionTest
+ */
 class PropertyUriDefinitionTest extends \PHPUnit_Framework_TestCase
 {
     public function testAssertIsInstanceOfAbstractPropertyDefinition()

--- a/tests/Unit/DataObjects/PropertyUriTest.php
+++ b/tests/Unit/DataObjects/PropertyUriTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\PropertyUri;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class PropertyUriTest
+ */
 class PropertyUriTest extends PropertyStringTest
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/RelationshipTypeDefinitionTest.php
+++ b/tests/Unit/DataObjects/RelationshipTypeDefinitionTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -12,6 +12,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
 use Dkd\PhpCmis\DataObjects\RelationshipTypeDefinition;
 
+/**
+ * Class RelationshipTypeDefinitionTest
+ */
 class RelationshipTypeDefinitionTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Unit/DataObjects/RelationshipTypeTest.php
+++ b/tests/Unit/DataObjects/RelationshipTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -17,6 +17,9 @@ use Dkd\PhpCmis\SessionInterface;
 use Dkd\PhpCmis\Test\Unit\ReflectionHelperTrait;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class RelationshipTypeTest
+ */
 class RelationshipTypeTest extends \PHPUnit_Framework_TestCase
 {
     use ReflectionHelperTrait;

--- a/tests/Unit/DataObjects/RenditionDataTest.php
+++ b/tests/Unit/DataObjects/RenditionDataTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\DataObjects\RenditionData;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class RenditionDataTest
+ */
 class RenditionDataTest extends \PHPUnit_Framework_TestCase
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/RenditionTest.php
+++ b/tests/Unit/DataObjects/RenditionTest.php
@@ -1,13 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit;
 
-use Dkd\PhpCmis\Data\RepositoryInfoInterface;
-use Dkd\PhpCmis\DataObjects\ObjectId;
-use Dkd\PhpCmis\DataObjects\Rendition;
-use Dkd\PhpCmis\SessionInterface;
-use PHPUnit_Framework_MockObject_MockObject;
-
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
@@ -16,6 +10,15 @@ use PHPUnit_Framework_MockObject_MockObject;
  * file that was distributed with this source code.
  */
 
+use Dkd\PhpCmis\Data\RepositoryInfoInterface;
+use Dkd\PhpCmis\DataObjects\ObjectId;
+use Dkd\PhpCmis\DataObjects\Rendition;
+use Dkd\PhpCmis\SessionInterface;
+use PHPUnit_Framework_MockObject_MockObject;
+
+/**
+ * Class RenditionTest
+ */
 class RenditionTest extends \PHPUnit_Framework_TestCase
 {
     use ReflectionHelperTrait;

--- a/tests/Unit/DataObjects/RepositoryCapabilitiesTest.php
+++ b/tests/Unit/DataObjects/RepositoryCapabilitiesTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -22,6 +22,9 @@ use Dkd\PhpCmis\Enum\CapabilityQuery;
 use Dkd\PhpCmis\Enum\CapabilityRenditions;
 use Dkd\PhpCmis\Test\Unit\DataProviderCollectionTrait;
 
+/**
+ * Class RepositoryCapabilitiesTest
+ */
 class RepositoryCapabilitiesTest extends \PHPUnit_Framework_TestCase
 {
     use DataProviderCollectionTrait;

--- a/tests/Unit/DataObjects/RepositoryInfoBrowserBindingTest.php
+++ b/tests/Unit/DataObjects/RepositoryInfoBrowserBindingTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -12,6 +12,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
 use Dkd\PhpCmis\DataObjects\RepositoryInfoBrowserBinding;
 
+/**
+ * Class RepositoryInfoBrowserBindingTest
+ */
 class RepositoryInfoBrowserBindingTest extends RepositoryInfoTest
 {
     public function setUp()

--- a/tests/Unit/DataObjects/RepositoryInfoTest.php
+++ b/tests/Unit/DataObjects/RepositoryInfoTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -14,6 +14,9 @@ use Dkd\PhpCmis\DataObjects\RepositoryInfo;
 use Dkd\PhpCmis\Enum\BaseTypeId;
 use Dkd\PhpCmis\Enum\CmisVersion;
 
+/**
+ * Class RepositoryInfoTest
+ */
 class RepositoryInfoTest extends \PHPUnit_Framework_TestCase
 {
     const DO_NOT_TEST_INVALID_TYPE_VALUE = 'doNotTestInvalidType';

--- a/tests/Unit/DataObjects/SecondaryTypeTest.php
+++ b/tests/Unit/DataObjects/SecondaryTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -14,6 +14,9 @@ use Dkd\PhpCmis\DataObjects\SecondaryType;
 use Dkd\PhpCmis\DataObjects\SecondaryTypeDefinition;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class SecondaryTypeTest
+ */
 class SecondaryTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructorSetsSession()

--- a/tests/Unit/DataProviderCollectionTrait.php
+++ b/tests/Unit/DataProviderCollectionTrait.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -10,6 +10,9 @@ namespace Dkd\PhpCmis\Test\Unit;
  * file that was distributed with this source code.
  */
 
+/**
+ * Class DataProviderCollectionTrait
+ */
 trait DataProviderCollectionTrait
 {
     /**

--- a/tests/Unit/FixtureHelperTrait.php
+++ b/tests/Unit/FixtureHelperTrait.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Dimitri Ebert <dimitri.ebert@dkd.de>

--- a/tests/Unit/ObjectFactoryTest.php
+++ b/tests/Unit/ObjectFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -16,6 +16,9 @@ use Dkd\PhpCmis\PropertyIds;
 use Dkd\PhpCmis\SessionInterface;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class ObjectFactoryTest
+ */
 class ObjectFactoryTest extends \PHPUnit_Framework_TestCase
 {
     use ReflectionHelperTrait;

--- a/tests/Unit/ObjectIdTest.php
+++ b/tests/Unit/ObjectIdTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -12,6 +12,9 @@ namespace Dkd\PhpCmis\Test\Unit;
 
 use Dkd\PhpCmis\DataObjects\ObjectId;
 
+/**
+ * Class ObjectIdTest
+ */
 class ObjectIdTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Unit/OperationContextTest.php
+++ b/tests/Unit/OperationContextTest.php
@@ -1,17 +1,21 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit;
 
-use Dkd\PhpCmis\Constants;
-use Dkd\PhpCmis\Enum\IncludeRelationships;
-use Dkd\PhpCmis\OperationContext;
-
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
+ */
+
+use Dkd\PhpCmis\Constants;
+use Dkd\PhpCmis\Enum\IncludeRelationships;
+use Dkd\PhpCmis\OperationContext;
+
+/**
+ * Class OperationContextTest
  */
 class OperationContextTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Unit/QueryResultTest.php
+++ b/tests/Unit/QueryResultTest.php
@@ -1,6 +1,15 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit;
 
+/*
+ * This file is part of php-cmis-lib.
+ *
+ * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Dkd\PhpCmis\DataObjects\AllowableActions;
 use Dkd\PhpCmis\DataObjects\ObjectData;
 use Dkd\PhpCmis\DataObjects\Properties;
@@ -12,14 +21,8 @@ use Dkd\PhpCmis\QueryResult;
 use PHPUnit_Framework_MockObject_MockObject;
 
 /**
- * This file is part of php-cmis-lib.
- *
- * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+ * Class QueryResultTest
  */
-
 class QueryResultTest extends \PHPUnit_Framework_TestCase
 {
     use ReflectionHelperTrait;

--- a/tests/Unit/QueryStatementTest.php
+++ b/tests/Unit/QueryStatementTest.php
@@ -1,6 +1,15 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit;
 
+/*
+ * This file is part of php-cmis-lib.
+ *
+ * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Dkd\PhpCmis\Data\ObjectIdInterface;
 use Dkd\PhpCmis\Data\ObjectTypeInterface;
 use Dkd\PhpCmis\DataObjects\DocumentType;
@@ -16,14 +25,8 @@ use Dkd\PhpCmis\SessionInterface;
 use PHPUnit_Framework_MockObject_MockObject;
 
 /**
- * This file is part of php-cmis-lib.
- *
- * (c) Dimitri Ebert <dimitri.ebert@dkd.de>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+ * Class QueryStatementTest
  */
-
 class QueryStatementTest extends \PHPUnit_Framework_TestCase
 {
     use ReflectionHelperTrait;

--- a/tests/Unit/ReflectionHelperTrait.php
+++ b/tests/Unit/ReflectionHelperTrait.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -10,6 +10,9 @@ namespace Dkd\PhpCmis\Test\Unit;
  * file that was distributed with this source code.
  */
 
+/**
+ * Class ReflectionHelperTrait
+ */
 trait ReflectionHelperTrait
 {
     /**

--- a/tests/Unit/SessionTest.php
+++ b/tests/Unit/SessionTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit;
 
-/**
+/*
  * This file is part of php-cmis-client
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -17,6 +17,9 @@ use Dkd\PhpCmis\Session;
 use Dkd\PhpCmis\SessionParameter;
 use PHPUnit_Framework_MockObject_MockObject;
 
+/**
+ * Class SessionTest
+ */
 class SessionTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructorThrowsExceptionIfNoParametersGiven()

--- a/tests/Unit/Traits/TypeHelperTraitTest.php
+++ b/tests/Unit/Traits/TypeHelperTraitTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 
-/**
+/*
  * This file is part of php-cmis-lib.
  *
  * (c) Sascha Egerer <sascha.egerer@dkd.de>
@@ -13,6 +13,9 @@ namespace Dkd\PhpCmis\Test\Unit\DataObjects;
 use Dkd\PhpCmis\Test\Unit\ReflectionHelperTrait;
 use Dkd\PhpCmis\Traits\TypeHelperTrait;
 
+/**
+ * Class TypeHelperTraitTest
+ */
 class TypeHelperTraitTest extends \PHPUnit_Framework_TestCase
 {
     use ReflectionHelperTrait;


### PR DESCRIPTION
This patch:

* Corrects the product name in license headers
* Removes confusion between class doc and license header
* Adds class doc where missing
* Fixes a case of static analysis return type mismatch Response/ResponseInterface