### PR TITLE
Make Travis build faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
 
 before_script:
   - composer self-update
-  - composer install --prefer-source --no-interaction --dev
+  - composer install --prefer-dist --no-interaction --dev
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
There's no difference except for speed when composer
prefers dist packages over source for deps. If source is
used, composer still clones the exact tag that's also
available as binary download.