### PR TITLE
Introduce read/post JSON returning wrappers

### DIFF
--- a/src/Bindings/Browser/AbstractBrowserBindingService.php
+++ b/src/Bindings/Browser/AbstractBrowserBindingService.php
@@ -35,6 +35,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Stream\StreamInterface;
 use GuzzleHttp\Exception\RequestException;
+use function json_decode;
 use League\Url\Url;
 use Psr\Http\Message\ResponseInterface;
 
@@ -179,10 +180,7 @@ abstract class AbstractBrowserBindingService implements LinkAccessInterface
         }
 
         $repositoryInfos = [];
-        $result = \json_decode(
-            $this->read($url)->getBody(),
-            true
-        );
+        $result = $this->readJson($url);
         if (!is_array($result)) {
             throw new CmisConnectionException(
                 'Could not fetch repository info! Response is not a valid JSON.',
@@ -232,6 +230,17 @@ abstract class AbstractBrowserBindingService implements LinkAccessInterface
     protected function getServiceUrl()
     {
         return $this->getSession()->get(SessionParameter::BROWSER_URL);
+    }
+
+    /**
+     * Wrapper to read URL response as JSON as is the general use case.
+     *
+     * @param Url $url
+     * @return mixed
+     */
+    protected function readJson(Url $url)
+    {
+        return json_decode($this->read($url)->getBody(), true);
     }
 
     /**
@@ -396,6 +405,19 @@ abstract class AbstractBrowserBindingService implements LinkAccessInterface
     }
 
     /**
+     * Wrapper for calling post() and reading response as JSON, as is the general use case.
+     *
+     * @param Url $url
+     * @param array $content
+     * @param array $headers
+     * @return mixed
+     */
+    protected function postJson(Url $url, $content = [], array $headers = [])
+    {
+        return \json_decode($this->post($url, $content, $headers)->getBody(), true);
+    }
+
+    /**
      * Performs a POST on an URL, checks the response code and returns the
      * result.
      *
@@ -444,10 +466,7 @@ abstract class AbstractBrowserBindingService implements LinkAccessInterface
         $url->getQuery()->modify([Constants::PARAM_TYPE_ID => $typeId]);
 
         return $this->getJsonConverter()->convertTypeDefinition(
-            (array) \json_decode(
-                $this->read($url)->getBody(),
-                true
-            )
+            (array) $this->readJson($url)
         );
     }
 

--- a/src/Bindings/Browser/DiscoveryService.php
+++ b/src/Bindings/Browser/DiscoveryService.php
@@ -75,7 +75,7 @@ class DiscoveryService extends AbstractBrowserBindingService implements Discover
             $url->getQuery()->modify([Constants::PARAM_MAX_ITEMS => (string) $maxItems]);
         }
 
-        $responseData = (array) \json_decode($this->read($url)->getBody(), true);
+        $responseData = (array) $this->readJson($url);
 
         // $changeLogToken was passed by reference. The value is changed here
         $changeLogToken = $responseData[JSONConstants::JSON_OBJECTLIST_CHANGE_LOG_TOKEN] ?? null;
@@ -142,8 +142,6 @@ class DiscoveryService extends AbstractBrowserBindingService implements Discover
             $url->getQuery()->modify([Constants::PARAM_MAX_ITEMS => (string) $maxItems]);
         }
 
-        $responseData = (array) \json_decode($this->post($url)->getBody(), true);
-
-        return $this->getJsonConverter()->convertQueryResultList($responseData);
+        return $this->getJsonConverter()->convertQueryResultList((array) $this->postJson($url));
     }
 }

--- a/src/Bindings/Browser/NavigationService.php
+++ b/src/Bindings/Browser/NavigationService.php
@@ -87,7 +87,7 @@ class NavigationService extends AbstractBrowserBindingService implements Navigat
             $url->getQuery()->modify([Constants::PARAM_RELATIONSHIPS => (string) $includeRelationships]);
         }
 
-        $responseData = (array) \json_decode($this->read($url)->getBody(), true);
+        $responseData = (array) $this->readJson($url);
 
         // TODO Implement Cache
         return $this->getJsonConverter()->convertObjectList($responseData);
@@ -159,7 +159,7 @@ class NavigationService extends AbstractBrowserBindingService implements Navigat
             $url->getQuery()->modify([Constants::PARAM_RELATIONSHIPS => (string) $includeRelationships]);
         }
 
-        $responseData = (array) \json_decode($this->read($url)->getBody(), true);
+        $responseData = (array) $this->readJson($url);
 
         // TODO Implement Cache
         return $this->getJsonConverter()->convertObjectInFolderList($responseData);
@@ -215,7 +215,7 @@ class NavigationService extends AbstractBrowserBindingService implements Navigat
             $url->getQuery()->modify([Constants::PARAM_RELATIONSHIPS => (string) $includeRelationships]);
         }
 
-        $responseData = (array) \json_decode($this->read($url)->getBody(), true);
+        $responseData = (array) $this->readJson($url);
 
         // TODO Implement Cache
         return $this->getJsonConverter()->convertDescendants($responseData);
@@ -249,7 +249,7 @@ class NavigationService extends AbstractBrowserBindingService implements Navigat
             $url->getQuery()->modify([Constants::PARAM_FILTER => (string) $filter]);
         }
 
-        $responseData = (array) \json_decode($this->read($url)->getBody(), true);
+        $responseData = (array) $this->readJson($url);
 
         // TODO Implement Cache
         return $this->getJsonConverter()->convertObject($responseData);
@@ -305,7 +305,7 @@ class NavigationService extends AbstractBrowserBindingService implements Navigat
             $url->getQuery()->modify([Constants::PARAM_RELATIONSHIPS => (string) $includeRelationships]);
         }
 
-        $responseData = (array) \json_decode($this->read($url)->getBody(), true);
+        $responseData = (array) $this->readJson($url);
 
         // TODO Implement Cache
         return $this->getJsonConverter()->convertDescendants($responseData);
@@ -358,7 +358,7 @@ class NavigationService extends AbstractBrowserBindingService implements Navigat
             $url->getQuery()->modify([Constants::PARAM_RELATIONSHIPS => (string) $includeRelationships]);
         }
 
-        $responseData = (array) \json_decode($this->read($url)->getBody(), true);
+        $responseData = (array) $this->readJson($url);
 
         // TODO Implement Cache
         return $this->getJsonConverter()->convertObjectParents($responseData);

--- a/src/Bindings/Browser/ObjectService.php
+++ b/src/Bindings/Browser/ObjectService.php
@@ -185,18 +185,15 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
             $queryArray[Constants::PARAM_VERSIONING_STATE] = (string) $versioningState;
         }
 
-        $responseData = (array) \json_decode(
-            $this->post(
+        $newObject = $this->getJsonConverter()->convertObject(
+            (array) $this->postJson(
                 $url,
                 array_merge(
                     $queryArray,
                     ['body' => $contentStream]
                 )
-            )->getBody(),
-            true
+            )
         );
-
-        $newObject = $this->getJsonConverter()->convertObject($responseData);
 
         if ($newObject) {
             $newObjectId = $newObject->getId();
@@ -257,9 +254,8 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
         if ($versioningState !== null) {
             $queryArray[Constants::PARAM_VERSIONING_STATE] = (string) $versioningState;
         }
-        $responseData = (array) \json_decode($this->post($url, $queryArray)->getBody(), true);
 
-        $newObject = $this->getJsonConverter()->convertObject($responseData);
+        $newObject = $this->getJsonConverter()->convertObject((array) $this->postJson($url, $queryArray));
 
         return ($newObject === null) ? null : $newObject->getId();
     }
@@ -301,9 +297,7 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
             $extension
         );
 
-        $responseData = (array) \json_decode($this->post($url, $queryArray)->getBody(), true);
-
-        $newObject = $this->getJsonConverter()->convertObject($responseData);
+        $newObject = $this->getJsonConverter()->convertObject((array) $this->postJson($url, $queryArray));
 
         return ($newObject === null) ? null : $newObject->getId();
     }
@@ -349,9 +343,7 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
             $extension
         );
 
-        $responseData = (array) \json_decode($this->post($url, $queryArray)->getBody(), true);
-
-        $newObject = $this->getJsonConverter()->convertObject($responseData);
+        $newObject = $this->getJsonConverter()->convertObject((array) $this->postJson($url, $queryArray));
 
         return ($newObject === null) ? null : $newObject->getId();
     }
@@ -418,9 +410,7 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
             $extension
         );
 
-        $responseData = (array) \json_decode($this->post($url, $queryArray)->getBody(), true);
-
-        $newObject = $this->getJsonConverter()->convertObject($responseData);
+        $newObject = $this->getJsonConverter()->convertObject((array) $this->postJson($url, $queryArray));
 
         return ($newObject === null) ? null : $newObject->getId();
     }
@@ -460,8 +450,7 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
             $url->getQuery()->modify([Constants::PARAM_CHANGE_TOKEN => $changeToken]);
         }
 
-        $responseData = (array) \json_decode($this->post($url)->getBody(), true);
-        $newObject = $this->getJsonConverter()->convertObject($responseData);
+        $newObject = $this->getJsonConverter()->convertObject((array) $this->postJson($url));
 
         // $objectId was passed by reference. The value is changed here to new object id
         $objectId = null;
@@ -540,14 +529,7 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
             $url->getQuery()->modify([Constants::PARAM_UNFILE_OBJECTS => (string) $unfileObjects]);
         }
 
-        $response = $this->post($url);
-
-        return $this->getJsonConverter()->convertFailedToDelete(
-            (array) (array) \json_decode(
-                $response->getBody(),
-                true
-            )
-        );
+        return $this->getJsonConverter()->convertFailedToDelete($this->postJson($url));
     }
 
     /**
@@ -680,7 +662,7 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
             $url->getQuery()->modify([Constants::PARAM_RELATIONSHIPS => (string) $includeRelationships]);
         }
 
-        $responseData = (array) \json_decode($this->read($url)->getBody(), true);
+        $responseData = (array) $this->readJson($url);
 
         return $this->cache(
             $cacheKey,
@@ -758,7 +740,7 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
             $url->getQuery()->modify([Constants::PARAM_RELATIONSHIPS => (string) $includeRelationships]);
         }
 
-        $responseData = (array) \json_decode($this->read($url)->getBody(), true);
+        $responseData = (array) $this->readJson($url);
 
         return $this->cache(
             $cacheKey,
@@ -808,7 +790,7 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
             $url->getQuery()->modify([Constants::PARAM_FILTER => (string) $filter]);
         }
 
-        $responseData = (array) \json_decode($this->read($url)->getBody(), true);
+        $responseData = (array) $this->readJson($url);
 
         if ($this->getSuccinct()) {
             $objectData = $this->getJsonConverter()->convertSuccinctProperties($responseData);
@@ -866,7 +848,7 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
             $url->getQuery()->modify([Constants::PARAM_MAX_ITEMS => (string) $maxItems]);
         }
 
-        $responseData = (array) \json_decode($this->read($url)->getBody(), true);
+        $responseData = (array) $this->readJson($url);
 
         return $this->getJsonConverter()->convertRenditions($responseData);
     }
@@ -901,8 +883,7 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
             ]
         );
 
-        $responseData = (array) \json_decode($this->post($url)->getBody(), true);
-        $newObject = $this->getJsonConverter()->convertObject($responseData);
+        $newObject = $this->getJsonConverter()->convertObject($this->postJson($url));
 
         // $objectId was passed by reference. The value is changed here to new object id
         $objectId = ($newObject === null) ? null : $newObject->getId();
@@ -953,12 +934,9 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
             $url->getQuery()->modify([Constants::PARAM_CHANGE_TOKEN => $changeToken]);
         }
 
-        $responseData = (array) \json_decode(
-            $this->post($url, ['content' => $contentStream])->getBody(),
-            true
+        $newObject = $this->getJsonConverter()->convertObject(
+            (array) $this->postJson($url, ['content' => $contentStream])
         );
-
-        $newObject = $this->getJsonConverter()->convertObject($responseData);
 
         // $objectId was passed by reference. The value is changed here to new object id
         $objectId = null;
@@ -1006,8 +984,7 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
         $queryArray = $this->convertPropertiesToQueryArray($properties);
         $queryArray[Constants::CONTROL_CMISACTION] = Constants::CMISACTION_UPDATE_PROPERTIES;
         $queryArray[Constants::PARAM_SUCCINCT] = $this->getSuccinct() ? 'true' : 'false';
-        $responseData = (array) \json_decode($this->post($url, $queryArray)->getBody(), true);
-        $newObject = $this->getJsonConverter()->convertObject($responseData);
+        $newObject = $this->getJsonConverter()->convertObject((array) $this->postJson($url, $queryArray));
 
         // $objectId was passed by reference. The value is changed here to new object id
         $objectId = null;

--- a/src/Bindings/Browser/RelationshipService.php
+++ b/src/Bindings/Browser/RelationshipService.php
@@ -87,7 +87,7 @@ class RelationshipService extends AbstractBrowserBindingService implements Relat
             $query->modify([Constants::PARAM_MAX_ITEMS =>  $maxItems]);
         }
 
-        $responseData = (array) \json_decode($this->read($url)->getBody(), true);
+        $responseData = (array) $this->readJson($url);
 
         return $this->getJsonConverter()->convertObjectList($responseData);
     }

--- a/src/Bindings/Browser/RepositoryService.php
+++ b/src/Bindings/Browser/RepositoryService.php
@@ -43,9 +43,7 @@ class RepositoryService extends AbstractBrowserBindingService implements Reposit
             ]
         );
 
-        $responseData = (array) \json_decode($this->post($url)->getBody(), true);
-
-        return $this->getJsonConverter()->convertTypeDefinition($responseData);
+        return $this->getJsonConverter()->convertTypeDefinition($this->postJson($url));
     }
 
     /**
@@ -141,7 +139,7 @@ class RepositoryService extends AbstractBrowserBindingService implements Reposit
             $url->getQuery()->modify([Constants::PARAM_MAX_ITEMS => $maxItems]);
         }
 
-        $responseData = (array) \json_decode($this->read($url)->getBody(), true);
+        $responseData = (array) $this->readJson($url);
 
         return $this->getJsonConverter()->convertTypeChildren($responseData);
     }
@@ -217,7 +215,7 @@ class RepositoryService extends AbstractBrowserBindingService implements Reposit
             $url->getQuery()->modify([Constants::PARAM_DEPTH => $depth]);
         }
 
-        $responseData = (array) \json_decode($this->read($url)->getBody(), true);
+        $responseData = (array) $this->readJson($url);
 
         return $this->getJsonConverter()->convertTypeDescendants($responseData);
     }
@@ -241,8 +239,6 @@ class RepositoryService extends AbstractBrowserBindingService implements Reposit
             ]
         );
 
-        $responseData = (array) \json_decode($this->post($url)->getBody(), true);
-
-        return $this->getJsonConverter()->convertTypeDefinition($responseData);
+        return $this->getJsonConverter()->convertTypeDefinition($this->postJson($url));
     }
 }

--- a/src/Bindings/Browser/VersioningService.php
+++ b/src/Bindings/Browser/VersioningService.php
@@ -34,19 +34,16 @@ class VersioningService extends AbstractBrowserBindingService implements Version
      */
     public function cancelCheckOut($repositoryId, & $objectId, ExtensionDataInterface $extension = null)
     {
-		$objectId = $this->getJsonConverter()->convertObject(
-            (array) \json_decode(
-                $this->post(
-                    $this->getObjectUrl($repositoryId, $objectId),
-                    $this->createQueryArray(
-                        Constants::CMISACTION_CANCEL_CHECK_OUT,
-                        [],
-                        $extension
-                    )
-                )->getBody(),
-                true
+        $objectId = $this->getJsonConverter()->convertObject(
+            (array) $this->postJson(
+                $this->getObjectUrl($repositoryId, $objectId),
+                $this->createQueryArray(
+                    Constants::CMISACTION_CANCEL_CHECK_OUT,
+                    [],
+                    $extension
+                )
             )
-		);
+        );
     }
 
     /**
@@ -79,52 +76,49 @@ class VersioningService extends AbstractBrowserBindingService implements Version
         AclInterface $removeAces = null,
         ExtensionDataInterface $extension = null
     ) {
-		$queryArray = $this->createQueryArray(
-			Constants::CMISACTION_CHECK_IN,
-			[
-				Constants::PARAM_MAJOR => $major ? 'true' : 'false',
-			],
-			$extension
-		);
-		if ($properties) {
-			$queryArray = array_replace(
-				$queryArray,
-				$this->convertPropertiesToQueryArray($properties)
-			);
-		}
-		if ($checkinComment) {
-			$queryArray[Constants::PARAM_CHECKIN_COMMENT] = $checkinComment;
-		}
-		if (!empty($policies)) {
-			$queryArray = array_replace(
-				$queryArray,
-				$this->convertPolicyIdArrayToQueryArray($policies)
-			);
-		}
-		if (!empty($removeAces)) {
-			$queryArray = array_replace($queryArray, $this->convertAclToQueryArray(
-				$removeAces,
-				Constants::CONTROL_REMOVE_ACE_PRINCIPAL,
-				Constants::CONTROL_REMOVE_ACE_PERMISSION
-			));
-		}
-		if (!empty($addAces)) {
-			$queryArray = array_replace($queryArray, $this->convertAclToQueryArray(
-				$addAces,
-				Constants::CONTROL_ADD_ACE_PRINCIPAL,
-				Constants::CONTROL_ADD_ACE_PERMISSION
-			));
-		}
-		if ($contentStream) {
-			$queryArray['content'] = $contentStream;
-		}
-		$objectId = $this->getJsonConverter()->convertObject(
-            (array) \json_decode(
-                $this->post(
-                    $this->getObjectUrl($repositoryId, $objectId),
-                    $queryArray
-                )->getBody(),
-                true
+        $queryArray = $this->createQueryArray(
+            Constants::CMISACTION_CHECK_IN,
+            [
+                Constants::PARAM_MAJOR => $major ? 'true' : 'false',
+            ],
+            $extension
+        );
+        if ($properties) {
+            $queryArray = array_replace(
+                $queryArray,
+                $this->convertPropertiesToQueryArray($properties)
+            );
+        }
+        if ($checkinComment) {
+            $queryArray[Constants::PARAM_CHECKIN_COMMENT] = $checkinComment;
+        }
+        if (!empty($policies)) {
+            $queryArray = array_replace(
+                $queryArray,
+                $this->convertPolicyIdArrayToQueryArray($policies)
+            );
+        }
+        if (!empty($removeAces)) {
+            $queryArray = array_replace($queryArray, $this->convertAclToQueryArray(
+                $removeAces,
+                Constants::CONTROL_REMOVE_ACE_PRINCIPAL,
+                Constants::CONTROL_REMOVE_ACE_PERMISSION
+            ));
+        }
+        if (!empty($addAces)) {
+            $queryArray = array_replace($queryArray, $this->convertAclToQueryArray(
+                $addAces,
+                Constants::CONTROL_ADD_ACE_PRINCIPAL,
+                Constants::CONTROL_ADD_ACE_PERMISSION
+            ));
+        }
+        if ($contentStream) {
+            $queryArray['content'] = $contentStream;
+        }
+        $objectId = $this->getJsonConverter()->convertObject(
+            (array) $this->postJson(
+                $this->getObjectUrl($repositoryId, $objectId),
+                $queryArray
             )
         )->getId();
     }
@@ -145,20 +139,17 @@ class VersioningService extends AbstractBrowserBindingService implements Version
         ExtensionDataInterface $extension = null,
         $contentCopied = null
     ) {
-		$objectData = $this->getJsonConverter()->convertObject(
-            (array) \json_decode(
-                $this->post(
-                    $this->getObjectUrl($repositoryId, $objectId),
-                    $this->createQueryArray(
-                        Constants::CMISACTION_CHECK_OUT,
-                        [],
-                        $extension
-                    )
-                )->getBody(),
-                true
+        $objectData = $this->getJsonConverter()->convertObject(
+            (array) $this->postJson(
+                $this->getObjectUrl($repositoryId, $objectId),
+                $this->createQueryArray(
+                    Constants::CMISACTION_CHECK_OUT,
+                    [],
+                    $extension
+                )
             )
-		);
-		$objectId = $objectData->getId();
+        );
+        $objectId = $objectData->getId();
     }
 
     /**
@@ -184,15 +175,12 @@ class VersioningService extends AbstractBrowserBindingService implements Version
         ExtensionDataInterface $extension = null
     ) {
         return $this->getJsonConverter()->convertObjectList(
-			[
-				'objects' => (array) \json_decode(
-                    $this->read(
-                        $this->getObjectUrl($repositoryId, $objectId, Constants::SELECTOR_VERSIONS)
-                    )->getBody(),
-                    true
+            [
+                'objects' => (array) $this->readJson(
+                    $this->getObjectUrl($repositoryId, $objectId, Constants::SELECTOR_VERSIONS)
                 )
-			]
-		)->getObjects();
+            ]
+        )->getObjects();
     }
 
     /**
@@ -229,13 +217,10 @@ class VersioningService extends AbstractBrowserBindingService implements Version
         $includeAcl = false,
         ExtensionDataInterface $extension = null
     ) {
-        $object = (array) \json_decode(
-            $this->read(
-                $this->getObjectUrl($repositoryId, $objectId, Constants::SELECTOR_VERSIONS)
-            )->getBody(),
-            true
+        $object = (array) $this->readJson(
+            $this->getObjectUrl($repositoryId, $objectId, Constants::SELECTOR_VERSIONS)
         );
-		return $this->getJsonConverter()->convertObject(reset($object));
+        return $this->getJsonConverter()->convertObject(reset($object));
     }
 
     /**
@@ -262,34 +247,34 @@ class VersioningService extends AbstractBrowserBindingService implements Version
         ExtensionDataInterface $extension = null
     ) {
         return $this->getObjectOfLatestVersion(
-			$repositoryId,
-			$objectId,
-			$versionSeriesId,
-			$major,
-			$filter,
-			$extension
-		)->getProperties();
+            $repositoryId,
+            $objectId,
+            $versionSeriesId,
+            $major,
+            $filter,
+            $extension
+        )->getProperties();
     }
 
-	/**
-	 * @param string $action
-	 * @param array $parameters
-	 * @param ExtensionDataInterface $extension
-	 * @return array
-	 */
-	protected function createQueryArray(
-		$action,
-		array $parameters = [],
-		ExtensionDataInterface $extension = null
-	) {
-		$queryArray = array_replace(
-			$parameters,
-			[
-				Constants::CONTROL_CMISACTION => $action,
-				Constants::PARAM_SUCCINCT => $this->getSuccinct() ? 'true' : 'false',
-			]
-		);
-		return $queryArray;
-	}
+    /**
+     * @param string $action
+     * @param array $parameters
+     * @param ExtensionDataInterface $extension
+     * @return array
+     */
+    protected function createQueryArray(
+        $action,
+        array $parameters = [],
+        ExtensionDataInterface $extension = null
+    ) {
+        $queryArray = array_replace(
+            $parameters,
+            [
+                Constants::CONTROL_CMISACTION => $action,
+                Constants::PARAM_SUCCINCT => $this->getSuccinct() ? 'true' : 'false',
+            ]
+        );
+        return $queryArray;
+    }
 
 }


### PR DESCRIPTION
Methods currently call read() or post() which returns a
Response - however, almost all methods do not care
about the response but always want JSON data.

Previously, Guzzle allowed chaing a ->json call on a
Response to get decoded JSON as array but this is no
longer possible, so these methods are introduced to
again cut down the code duplication in Response parsing.