### PR TITLE
Fix for undefined index error

### DIFF
--- a/src/Converter/JsonConverter.php
+++ b/src/Converter/JsonConverter.php
@@ -833,7 +833,7 @@ class JsonConverter extends AbstractDataConverter
         } else {
             $properties = $this->convertProperties(
                 $data[JSONConstants::JSON_OBJECT_PROPERTIES] ?? [],
-                (array) $data[JSONConstants::JSON_OBJECT_PROPERTIES_EXTENSION] ?? []
+                $data[JSONConstants::JSON_OBJECT_PROPERTIES_EXTENSION] ?? []
             );
         }
 

--- a/src/Converter/JsonConverter.php
+++ b/src/Converter/JsonConverter.php
@@ -829,11 +829,12 @@ class JsonConverter extends AbstractDataConverter
         if (isset($data[JSONConstants::JSON_OBJECT_SUCCINCT_PROPERTIES])) {
             $properties = $this->convertSuccinctProperties(
                 $data[JSONConstants::JSON_OBJECT_SUCCINCT_PROPERTIES] ?? [],
-                $data[JSONConstants::JSON_OBJECT_PROPERTIES_EXTENSION] ?? []);
+                (array) ($data[JSONConstants::JSON_OBJECT_PROPERTIES_EXTENSION] ?? [])
+            );
         } else {
             $properties = $this->convertProperties(
                 $data[JSONConstants::JSON_OBJECT_PROPERTIES] ?? [],
-                $data[JSONConstants::JSON_OBJECT_PROPERTIES_EXTENSION] ?? []
+                (array) ($data[JSONConstants::JSON_OBJECT_PROPERTIES_EXTENSION] ?? [])
             );
         }
 


### PR DESCRIPTION
Removed the (array) cast, an error is triggered when JSONConstants::JSON_OBJECT_PROPERTIES_EXTENSION is not set in $data.