### PR TITLE
Fix some more undefined index errors

### DIFF
--- a/src/Converter/JsonConverter.php
+++ b/src/Converter/JsonConverter.php
@@ -918,7 +918,7 @@ class JsonConverter extends AbstractDataConverter
             $property = $this->getPropertyByPropertyType(
                 $propertyType,
                 $id,
-                (array) $propertyData[JSONConstants::JSON_PROPERTY_VALUE] ?? []
+                (array) ($propertyData[JSONConstants::JSON_PROPERTY_VALUE] ?? [])
             );
             $property->populate(
                 $propertyData,
@@ -1645,7 +1645,7 @@ class JsonConverter extends AbstractDataConverter
         $objectList = new ObjectList();
         $objects = [];
 
-        foreach ((array) $data[JSONConstants::JSON_OBJECTLIST_OBJECTS] ?? [] as $objectData) {
+        foreach ((array) ($data[JSONConstants::JSON_OBJECTLIST_OBJECTS] ?? []) as $objectData) {
             $object = $this->convertObject($objectData);
 
             if ($object !== null) {
@@ -1683,7 +1683,7 @@ class JsonConverter extends AbstractDataConverter
         $objectList = new ObjectList();
         $objects = [];
 
-        foreach ((array) ($data[JSONConstants::JSON_QUERYRESULTLIST_RESULTS]) ?? [] as $objectData) {
+        foreach ((array) ($data[JSONConstants::JSON_QUERYRESULTLIST_RESULTS] ?? []) as $objectData) {
             $object = $this->convertObject($objectData);
 
             if ($object !== null) {


### PR DESCRIPTION
There are some places where the usage of an array cast in
combination with the null coalescing operator ends in an undefined
index error and the actual cast is not executed at all.
Fix those places by adding some braces around the null coalescing
check before casting the end result to an array.

Not sure if the array cast is required at all because the passed
value must be an array and casting it could lead to an unexpected
result in case of providing an invalid value. But that is a different
issue.