### PR TITLE
Make deleteObject work with alfresco

### DIFF
--- a/src/Bindings/Browser/ObjectService.php
+++ b/src/Bindings/Browser/ObjectService.php
@@ -478,14 +478,12 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
         ExtensionDataInterface $extension = null
     ) {
         $url = $this->getObjectUrl($repositoryId, $objectId);
-        $url->getQuery()->modify(
-            [
-                Constants::CONTROL_CMISACTION => Constants::CMISACTION_DELETE,
-                Constants::PARAM_ALL_VERSIONS => $allVersions ? 'true' : 'false',
-            ]
-        );
+        $content = [
+           Constants::CONTROL_CMISACTION => Constants::CMISACTION_DELETE,
+           Constants::PARAM_ALL_VERSIONS => $allVersions ? 'true' : 'false',
+           ];
 
-        $this->post($url);
+        $this->post($url, $content);
         $this->flushCached();
     }
 

--- a/tests/Unit/Bindings/Browser/ObjectServiceTest.php
+++ b/tests/Unit/Bindings/Browser/ObjectServiceTest.php
@@ -608,7 +608,11 @@ class ObjectServiceTest extends AbstractBrowserBindingServiceTestCase
             $objectId
         )->willReturn(Url::createFromUrl(self::BROWSER_URL_TEST));
         $objectService->expects($this->atLeastOnce())->method('post')->with(
-            $expectedUrl
+              $expectedUrl,
+              [
+                  'cmisaction' => 'delete',
+                  'allVersions' => $allVersions ? 'true' : 'false'
+              ]
         )->willReturn($responseMock);
 
         $objectService->deleteObject(
@@ -629,7 +633,6 @@ class ObjectServiceTest extends AbstractBrowserBindingServiceTestCase
             [
                 Url::createFromUrl(
                     self::BROWSER_URL_TEST
-                    . '?cmisaction=delete&allVersions=true'
                 ),
                 'repositoryId',
                 'objectId',
@@ -638,7 +641,6 @@ class ObjectServiceTest extends AbstractBrowserBindingServiceTestCase
             [
                 Url::createFromUrl(
                     self::BROWSER_URL_TEST
-                    . '?cmisaction=delete&allVersions=false'
                 ),
                 'repositoryId',
                 'objectId',


### PR DESCRIPTION
To delete an object, we have to put the request into the body, see https://stackoverflow.com/a/42951300/1230592

With this patch, deleteObject works with Alfresco 5.2