### PR TITLE
Allow null as value for localNamespace property

### DIFF
--- a/src/DataObjects/AbstractTypeDefinition.php
+++ b/src/DataObjects/AbstractTypeDefinition.php
@@ -169,7 +169,7 @@ abstract class AbstractTypeDefinition extends AbstractExtensionData implements T
      */
     public function setLocalNamespace($localNamespace)
     {
-        $this->localNamespace = $this->castValueToSimpleType('string', $localNamespace);
+        $this->localNamespace = $this->castValueToSimpleType('string', $localNamespace, true);
     }
 
     /**

--- a/tests/Unit/DataObjects/AbstractTypeDefinitionTest.php
+++ b/tests/Unit/DataObjects/AbstractTypeDefinitionTest.php
@@ -65,8 +65,8 @@ class AbstractTypeDefinitionTest extends \PHPUnit_Framework_TestCase
         foreach ($this->stringProperties as $propertyName) {
             foreach ($this->stringCastDataProvider() as $stringPropertyTestValues) {
                 $testDataSet = $stringPropertyTestValues;
-                // allow/expect null value for property parentTypeId
-                if ($testDataSet[1] === null && $propertyName === 'parentTypeId') {
+                // allow/expect null value for some properties
+                if ($testDataSet[1] === null && ($propertyName === 'parentTypeId' || $propertyName === 'localNamespace')) {
                     $testDataSet[0] = null;
                 }
                 array_unshift($testDataSet, $propertyName);


### PR DESCRIPTION
The property `localNamespace` is not required and so the
value sometimes can be null. To prevent error notices "value has been casted
from null to string" the value is not casted anymore from null to string.

Fixes #63 