### PR TITLE
Fixes #67: Ignore extension properties when parsing definition.

### DIFF
--- a/src/Converter/JsonConverter.php
+++ b/src/Converter/JsonConverter.php
@@ -676,7 +676,7 @@ class JsonConverter extends AbstractDataConverter
 //        }
 
         $propertyDefinition->populate(
-            $data,
+            array_intersect_key($data, array_fill_keys(JSONConstants::getPropertyTypeKeys(), 1)),
             [JSONConstants::JSON_PROPERTY_TYPE_RESOLUTION => 'dateTimeResolution']
         );
         $propertyDefinition->setExtensions($this->convertExtension($data, JSONConstants::getPropertyTypeKeys()));

--- a/tests/Fixtures/Cmis/v1.1/BrowserBinding/getTypeDefinitionHidden-response.log
+++ b/tests/Fixtures/Cmis/v1.1/BrowserBinding/getTypeDefinitionHidden-response.log
@@ -1,0 +1,35 @@
+{
+    "fulltextIndexed":false,
+    "localName":"cmis:folder",
+    "fileable":true,
+    "includedInSupertypeQuery":true,
+    "queryName":"cmis:folder",
+    "controllablePolicy":false,
+    "creatable":true,
+    "id":"cmis:folder",
+    "propertyDefinitions":{
+        "cmis:id":{
+            "localName":"cmis:idValue",
+            "queryName":"cmis:idValue",
+            "inherited":false,
+            "openChoice":false,
+            "id":"cmis:id",
+            "orderable":true,
+            "propertyType":"id",
+            "description":"This is a id property.",
+            "updatability":"readonly",
+            "localNamespace":"local",
+            "displayName":"Id property",
+            "required":true,
+            "cardinality":"single",
+            "queryable":true,
+            "isHidden": true
+        }
+    },
+    "controllableACL":true,
+    "description":"Description of CMIS Folder Type",
+    "localNamespace":"local",
+    "displayName":"CMIS Folder",
+    "baseId":"cmis:folder",
+    "queryable":false
+}

--- a/tests/Fixtures/Cmis/v1.1/BrowserBinding/getTypeDefinitionHidden-response.log
+++ b/tests/Fixtures/Cmis/v1.1/BrowserBinding/getTypeDefinitionHidden-response.log
@@ -23,7 +23,7 @@
             "required":true,
             "cardinality":"single",
             "queryable":true,
-            "isHidden": true
+            "aCustomPropertyFromTheServer": true
         }
     },
     "controllableACL":true,

--- a/tests/Unit/Converter/JsonConverterTest.php
+++ b/tests/Unit/Converter/JsonConverterTest.php
@@ -1190,4 +1190,27 @@ class JsonConverterTest extends \PHPUnit_Framework_TestCase
 
         return $data;
     }
+
+    public function testConvertPropertyDefinitionIgnoresUnrecognizedProperty()
+    {
+      $propertyDefinitions = $this->getResponseFixtureContentAsArray(
+          'Cmis/v1.1/BrowserBinding/getTypeDefinitionHidden-response.log'
+      )['propertyDefinitions'];
+      $expectedObjects = require(__DIR__ . '/../../Fixtures/Php/PropertyDefinitionsFixture.php');
+
+      $extensions = [new CmisExtensionElement(
+          null,
+          'isHidden',
+          [],
+          true
+      )];
+      $expectedObjects['cmis:id']->setExtensions($extensions);
+
+      $this->assertEquals(
+        $expectedObjects['cmis:id'],
+        $this->jsonConverter->convertPropertyDefinition(
+          $propertyDefinitions['cmis:id']
+        )
+      );
+    }
 }

--- a/tests/Unit/Converter/JsonConverterTest.php
+++ b/tests/Unit/Converter/JsonConverterTest.php
@@ -1200,7 +1200,7 @@ class JsonConverterTest extends \PHPUnit_Framework_TestCase
 
       $extensions = [new CmisExtensionElement(
           null,
-          'isHidden',
+          'aCustomPropertyFromTheServer',
           [],
           true
       )];


### PR DESCRIPTION
When populating the type definition properties, filter out any non CMIS 1.1 known properties so that they can be properly parsed as extension properties.