### PR TITLE
Fix download URLs with query parameters

### DIFF
--- a/src/Bindings/Browser/ObjectService.php
+++ b/src/Bindings/Browser/ObjectService.php
@@ -574,7 +574,7 @@ class ObjectService extends AbstractBrowserBindingService implements ObjectServi
         }
 
         /** @var Response $response */
-        $response = $this->getHttpInvoker()->get((string) $url);
+        $response = $this->getHttpInvoker()->get(str_replace("&", "&amp;", (string) $url));
 
         $contentStream = $response->getBody();
         if (!$contentStream) {


### PR DESCRIPTION
Hello,

I don't know whether this project is still maintained nor whether this patch is correct but we had to patch URL generation in order to fix file downloading using this module with Nuxeo. To be honest I don't really know why this is necessary ; just up-streaming it in case it was something missing or if it can be useful to anyone.

I'd be happy to add a unit test for that if you think such fix does make sense.

Have a nice day.