### PR TITLE
Guzzle 7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=7.0.0",
         "dkd/enumeration": "~0.1",
         "dkd/php-populate": "^1",
-        "guzzlehttp/guzzle": "^6",
+        "guzzlehttp/guzzle": "^6|^7",
         "guzzlehttp/streams": "^3",
         "doctrine/cache": "^1",
         "league/url": "^2|^3"


### PR DESCRIPTION
Fixes https://github.com/dkd/php-cmis-client/issues/82.

It seems to work correctly, at least for the subset of functionalities we are using.
But we might want to check this list: https://github.com/guzzle/guzzle/blob/7.8/UPGRADING.md#60-to-70